### PR TITLE
fix: preserve namespaces for empty for_each expansions

### DIFF
--- a/base_config.go
+++ b/base_config.go
@@ -38,7 +38,9 @@ type BaseConfig struct {
 	inputVariables           map[string]VariableValueRead
 	inputVariableReadsLoader *sync.Once
 	ignoreUnknownVariables   bool
-	OverrideFunctions        map[string]function.Function
+	// Empty expansions leave the DAG but still need an addressable evaluation namespace.
+	emptyForEachBlocks map[string]Block
+	OverrideFunctions  map[string]function.Function
 }
 
 func (c *BaseConfig) Context() context.Context {
@@ -57,8 +59,16 @@ func (c *BaseConfig) EmptyEvalContext() *hcl.EvalContext {
 
 func (c *BaseConfig) EvalContext() *hcl.EvalContext {
 	ctx := c.EmptyEvalContext()
-	for bt, bs := range c.blocksByTypes() {
-		sample := bs[0]
+	blocksByTypes := c.blocksByTypes()
+	emptyForEachBlocksByTypes := c.emptyForEachBlocksByTypes()
+	for bt := range emptyForEachBlocksByTypes {
+		if _, ok := blocksByTypes[bt]; !ok {
+			blocksByTypes[bt] = nil
+		}
+	}
+	for bt, bs := range blocksByTypes {
+		emptyForEachBlocks := emptyForEachBlocksByTypes[bt]
+		sample := firstBlock(bs, emptyForEachBlocks)
 		if s, ok := sample.(BlockCustomizedRefType); ok {
 			bt = s.CustomizedRefType()
 		}
@@ -66,7 +76,7 @@ func (c *BaseConfig) EvalContext() *hcl.EvalContext {
 			ctx.Variables[bt] = SingleValues(castBlock[SingleValueBlock](bs))
 			continue
 		}
-		ctx.Variables[bt] = Values(bs)
+		ctx.Variables[bt] = valuesWithEmptyForEach(bs, emptyForEachBlocks)
 	}
 	return ctx
 }
@@ -91,6 +101,7 @@ func NewBasicConfig(basedir, dslFullName, dslAbbreviation string, varConfigDir *
 		d:                        newDag(),
 		inputVariableReadsLoader: &sync.Once{},
 		rawBlockAddresses:        make(map[string]struct{}),
+		emptyForEachBlocks:       make(map[string]Block),
 	}
 	return c
 }
@@ -271,6 +282,24 @@ func (c *BaseConfig) blocksByTypes() map[string][]Block {
 	return r
 }
 
+func (c *BaseConfig) emptyForEachBlocksByTypes() map[string][]Block {
+	r := make(map[string][]Block)
+	for _, b := range c.emptyForEachBlocks {
+		bt := b.BlockType()
+		r[bt] = append(r[bt], b)
+	}
+	return r
+}
+
+func firstBlock(groups ...[]Block) Block {
+	for _, group := range groups {
+		if len(group) > 0 {
+			return group[0]
+		}
+	}
+	return nil
+}
+
 func (c *BaseConfig) buildDag(blocks []Block) error {
 	for _, b := range blocks {
 		c.rawBlockAddresses[b.Address()] = struct{}{}
@@ -334,7 +363,16 @@ func (c *BaseConfig) expandBlock(b Block) ([]Block, error) {
 		}
 	}
 	b.markExpanded()
-	return expandedBlocks, c.d.DeleteVertex(address)
+	if err := c.d.DeleteVertex(address); err != nil {
+		return expandedBlocks, err
+	}
+	if len(expandedBlocks) == 0 {
+		if c.emptyForEachBlocks == nil {
+			c.emptyForEachBlocks = make(map[string]Block)
+		}
+		c.emptyForEachBlocks[address] = b
+	}
+	return expandedBlocks, nil
 }
 
 func Traverse[T Block](c *BaseConfig, walker func(b T) error) error {

--- a/block.go
+++ b/block.go
@@ -163,11 +163,24 @@ func SingleValues(blocks []SingleValueBlock) cty.Value {
 }
 
 func Values[T Block](blocks []T) cty.Value {
-	if len(blocks) == 0 {
+	return valuesWithEmptyForEach(blocks, nil)
+}
+
+func valuesWithEmptyForEach[T Block](blocks []T, emptyForEachBlocks []Block) cty.Value {
+	if len(blocks) == 0 && len(emptyForEachBlocks) == 0 {
 		return cty.EmptyObjectVal
 	}
 	res := map[string]cty.Value{}
 	valuesMap := map[string]map[string]cty.Value{}
+
+	for _, b := range emptyForEachBlocks {
+		values, exists := valuesMap[b.Type()]
+		if !exists {
+			values = map[string]cty.Value{}
+		}
+		values[b.Name()] = cty.EmptyObjectVal
+		valuesMap[b.Type()] = values
+	}
 
 	for _, b := range blocks {
 		values, exists := valuesMap[b.Type()]

--- a/config_test.go
+++ b/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/zclconf/go-cty/cty"
 )
 
 var _ Config = &DummyConfig{}
@@ -312,6 +313,41 @@ func (s *configSuite) TestForEach_forEachAsToggle() {
 	config, err := BuildDummyConfig("", "", nil, nil)
 	require.NoError(s.T(), err)
 	s.Len(Blocks[TestData](config), 0)
+}
+
+func (s *configSuite) TestForEach_EmptyCollectionShouldRegisterNamespace() {
+	hclConfig := `
+data "dummy" "sibling" {}
+
+data "dummy" "empty" {
+	for_each = []
+}
+
+resource "dummy" "downstream" {
+	for_each = data.dummy.empty
+}
+`
+	s.dummyFsWithFiles(map[string]string{
+		"test.hcl": hclConfig,
+	})
+
+	config, err := BuildDummyConfig("", "", nil, nil)
+	require.NoError(s.T(), err)
+	_, err = RunDummyPlan(config)
+	require.NoError(s.T(), err)
+
+	s.Len(Blocks[TestData](config), 1)
+	s.Empty(Blocks[TestResource](config))
+	for _, reference := range []string{
+		"data.dummy.empty",
+		"resource.dummy.downstream",
+	} {
+		expr, diag := hclsyntax.ParseExpression([]byte(reference), "", hcl.InitialPos)
+		require.False(s.T(), diag.HasErrors())
+		value, diag := expr.Value(config.EvalContext())
+		require.False(s.T(), diag.HasErrors(), diag.Error())
+		s.True(value.RawEquals(cty.EmptyObjectVal))
+	}
 }
 
 func (s *configSuite) TestForEach_blocksWithIndexShouldHasNewBlockId() {


### PR DESCRIPTION
## Problem

When a top-level block uses `for_each`, `BaseConfig.expandBlock` removes the original template block from the executable DAG after expansion. If the collection is empty, no expanded vertices replace it. `EvalContext` is built only from the remaining DAG vertices, so the entire block address disappears from the HCL namespace instead of evaluating to an empty object.

For example:

```hcl
data "dummy" "empty" {
  for_each = {}
}

resource "dummy" "downstream" {
  for_each = data.dummy.empty
}
```

The first block correctly creates no instances, but the second expression fails with an unknown reference for `data.dummy.empty`. Logically, that address should exist as an empty collection so the downstream block also expands to zero instances. Without that behavior, configuration authors must wrap every chained reference in `try(data.dummy.empty, {})`.

This surfaced in Azure/mapotf#110, where an empty `data.module_source.for_order` expansion prevented a downstream transform from evaluating its `for_each`.

## Fix

Preserve zero-instance templates as evaluation-only metadata:

- record the original template in `emptyForEachBlocks` when expansion creates no instances
- continue deleting the template from the executable DAG
- include both live blocks and empty-expansion metadata when constructing `EvalContext`
- materialize each empty address as `cty.EmptyObjectVal` through `valuesWithEmptyForEach`

Keeping this metadata outside the DAG is important: an empty template remains absent from `Blocks[T]`, planning, dependency traversal, and Apply. It exists only so expressions can resolve the address and naturally produce another empty expansion.

## Tests

The regression test creates a real sibling block, an empty data expansion, and a downstream resource whose `for_each` references that empty namespace. It verifies that:

- planning completes without an unknown-reference diagnostic
- the real sibling remains the only data block returned by `Blocks[T]`
- no downstream resource instance is created
- both empty addresses evaluate to `cty.EmptyObjectVal`

Validated with:

- `go test ./... -count=1`
- `go vet ./...`
- changed-code `golangci-lint`: 0 issues
- statement coverage: 84.7%

Addresses [Azure/mapotf#110](https://github.com/Azure/mapotf/issues/110).