### PR TITLE
Align for_each validation with key semantics

### DIFF
--- a/base_config.go
+++ b/base_config.go
@@ -293,8 +293,8 @@ func (c *BaseConfig) expandBlock(b Block) ([]Block, error) {
 	if diag.HasErrors() {
 		return nil, diag
 	}
-	if !forEachValue.CanIterateElements() {
-		return nil, fmt.Errorf("invalid `for_each`, except set or map: %s", attr.Range().String())
+	if err := validateForEachCollectionType(forEachValue, attr.Range()); err != nil {
+		return nil, err
 	}
 	address := b.Address()
 	upstreams, err := c.d.GetAncestors(address)
@@ -335,6 +335,22 @@ func (c *BaseConfig) expandBlock(b Block) ([]Block, error) {
 	}
 	b.markExpanded()
 	return expandedBlocks, c.d.DeleteVertex(address)
+}
+
+func validateForEachCollectionType(value cty.Value, sourceRange hcl.Range) error {
+	valueType := value.Type()
+	if valueType.IsMapType() || valueType.IsObjectType() {
+		return nil
+	}
+	if valueType.IsSetType() {
+		if valueType.ElementType() == cty.String {
+			return nil
+		}
+		if !value.IsNull() && value.IsKnown() && value.LengthInt() == 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid `for_each`; must be a map or set of strings, got %s: %s", valueType.FriendlyName(), sourceRange.String())
 }
 
 func Traverse[T Block](c *BaseConfig, walker func(b T) error) error {

--- a/block_test.go
+++ b/block_test.go
@@ -730,7 +730,7 @@ func TestBlockToString(t *testing.T) {
 
 func TestMultipleInstanceDataBlockWithNestedBlock(t *testing.T) {
 	code := `data "dummy" this {
-    for_each = toset([1,2])
+    for_each = { "1" = 1, "2" = 2 }
 	dynamic "top_nested_block" {
 		for_each = range(each.value)
 		content {

--- a/config_test.go
+++ b/config_test.go
@@ -245,7 +245,7 @@ locals {
 func (s *configSuite) TestForEach_ForEachBlockShouldBeExpanded() {
 	hclConfig := `
 	locals {
-		items = ["item1", "item2", "item3"]
+		items = toset(["item1", "item2", "item3"])
 	}
 
 	data "dummy" "foo" {
@@ -302,7 +302,7 @@ func (s *configSuite) TestForEach_forEachAsToggle() {
     }
 
     data "dummy" sample {
-        for_each = false ? locals.items : []
+        for_each = false ? local.items : toset([])
     }
     `
 	s.dummyFsWithFiles(map[string]string{
@@ -376,20 +376,20 @@ func (s *configSuite) TestExpandableApplyBlockWithZeroLengthShouldNotBlockDownst
     }
 
 	resource "dummy" foobar {
-	    for_each = []
+	    for_each = {}
 		tags = {
 		  foo = local.foo
 		}
 	}
 
 	resource "dummy" bar {
-        for_each = []
+        for_each = {}
 		tags = {}
 		depends_on = [resource.dummy.foobar]
 	}
 
     resource "dummy" foo {
-        for_each = []
+        for_each = {}
 		tags = {}
         depends_on = [resource.dummy.bar]
 	}

--- a/for_each_test.go
+++ b/for_each_test.go
@@ -1,6 +1,7 @@
 package golden
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -34,7 +35,7 @@ func (s *forEachTestSuite) TearDownSubTest() {
 func (s *forEachTestSuite) TestForEachBlockWithAttributeThatHasDefaultValue() {
 	config := `	
 	data "dummy" "sample" {
-		for_each = toset([1,2,3])
+		for_each = toset(["1","2","3"])
 	}
 `
 	s.dummyFsWithFiles(map[string]string{
@@ -63,7 +64,7 @@ data "dummy" "sample" {
 }
 
 variable "numbers" {
-	type = set(number)
+	type = set(string)
 }
 `,
 			desc: "without_validation",
@@ -76,7 +77,7 @@ data "dummy" "sample" {
 }
 
 variable "numbers" {
-	type = set(number)
+	type = set(string)
 	validation {
 		condition = length(var.numbers) > 0
 		error_message = "numbers must not be empty"
@@ -96,7 +97,7 @@ variable "dummy" {
 				"test.hcl": c.config,
 			})
 			c, err := BuildDummyConfig("", "", []CliFlagAssignedVariables{
-				NewCliFlagAssignedVariable("numbers", "[1]"),
+				NewCliFlagAssignedVariable("numbers", `["1"]`),
 			}, nil)
 			require.NoError(s.T(), err)
 			_, err = RunDummyPlan(c)
@@ -108,7 +109,7 @@ variable "dummy" {
 func (s *forEachTestSuite) TestLocals_locals_as_for_each() {
 	code := `
 locals {
-  numbers = toset([1,2,3])
+  numbers = toset(["1","2","3"])
 }
 
 data "dummy" foo {
@@ -147,4 +148,44 @@ resource "dummy" bar {
 	p, err := RunDummyPlan(c)
 	s.NoError(err)
 	s.Len(p.Resources, 3)
+}
+
+func (s *forEachTestSuite) TestForEachCollectionTypes() {
+	tests := []struct {
+		name          string
+		forEach       string
+		wantInstances int
+		wantError     bool
+	}{
+		{name: "map", forEach: `tomap({ a = "one", b = "two" })`, wantInstances: 2},
+		{name: "object", forEach: `{ a = 1, b = true }`, wantInstances: 2},
+		{name: "set of strings", forEach: `toset(["a", "b"])`, wantInstances: 2},
+		{name: "empty map", forEach: `tomap({})`},
+		{name: "empty object", forEach: `{}`},
+		{name: "empty set", forEach: `toset([])`},
+		{name: "list", forEach: `tolist(["a", "b"])`, wantError: true},
+		{name: "tuple", forEach: `["a", "b"]`, wantError: true},
+		{name: "empty tuple", forEach: `[]`, wantError: true},
+		{name: "set of numbers", forEach: `toset([1, 2])`, wantError: true},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.dummyFsWithFiles(map[string]string{
+				"test.hcl": fmt.Sprintf(`
+data "dummy" "sample" {
+  for_each = %s
+}
+`, test.forEach),
+			})
+
+			config, err := BuildDummyConfig("", "", nil, nil)
+			if test.wantError {
+				s.ErrorContains(err, "must be a map or set of strings")
+				return
+			}
+			s.NoError(err)
+			s.Len(Blocks[TestData](config), test.wantInstances)
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`BaseConfig.expandBlock` currently treats every cty value for which `CanIterateElements()` returns true as a valid top-level `for_each` value. That method only says that a value is iterable; it does not say that its elements have valid, stable instance-key semantics.

As a result, all of these configurations currently reach expansion:

```hcl
data "dummy" "from_tuple" {
  for_each = ["a", "b"]
}

data "dummy" "from_list" {
  for_each = tolist(["a", "b"])
}

data "dummy" "from_number_set" {
  for_each = toset([1, 2])
}
```

Tuple/list indices and non-string cty values are converted to address keys by `CtyValueToString`. This accepts a broader contract than the existing error message states, differs from Terraform-style `for_each`, and makes instance-address stability depend on undocumented conversions.

## Fix

Replace the generic iterability check with a focused `validateForEachCollectionType` helper before expansion. The accepted key families are now explicit:

- maps and objects are accepted because their attribute keys provide stable string instance keys
- sets of strings are accepted because each string becomes the instance key
- a known empty set is accepted even when cty inferred a dynamic element type, preserving the canonical `toset([])` zero-instance form
- lists, tuples, non-string sets, and other values are rejected

The returned error reports the actual friendly cty type, the required `map or set of strings` contract, and the source range of the `for_each` attribute.

This change applies only to top-level block expansion, where keys become addressable block instances. Dynamic block iteration remains unchanged because it generates nested block content rather than addressable top-level instances. Null and unknown value availability is handled separately by #90; this PR defines only the accepted collection types.

## Tests

Table-driven regression coverage verifies acceptance of maps, objects, `set(string)`, empty maps/objects/sets, and rejection of lists, tuples, empty tuples, and `set(number)`. Existing fixtures that relied on numeric set keys or sequence iteration were migrated to explicit string-keyed sets or maps.

Validated with:

- `go test ./...`
- `go vet ./...`

Fixes #85