### PR TITLE
Validate labels before constructing registered blocks

### DIFF
--- a/base_block.go
+++ b/base_block.go
@@ -24,7 +24,7 @@ type BaseBlock struct {
 
 func NewBaseBlock(c Config, hb *HclBlock) *BaseBlock {
 	n := ""
-	if hb != nil {
+	if hb != nil && len(hb.Labels) > 1 {
 		n = hb.Labels[1]
 	}
 	bb := &BaseBlock{

--- a/config.go
+++ b/config.go
@@ -78,7 +78,51 @@ func wrapBlock(c Config, hb *HclBlock) (Block, error) {
 	if !ok {
 		return nil, fmt.Errorf("unregistered %s: %s", hb.Type, blockType)
 	}
+	if diags := validateBlockLabels(hb, blockType); diags.HasErrors() {
+		return nil, diags
+	}
 	return f(c, hb), nil
+}
+
+func validateBlockLabels(hb *HclBlock, blockType string) hcl.Diagnostics {
+	const expectedLabelCount = 2
+	if len(hb.Labels) == expectedLabelCount {
+		return nil
+	}
+
+	blockDescription := fmt.Sprintf("%q", hb.Type)
+	expectedSyntax := fmt.Sprintf("%s \"NAME\" {\n  ...\n}", hb.Type)
+	if blockType != "" {
+		blockDescription = fmt.Sprintf("%s %q", hb.Type, blockType)
+		expectedSyntax = fmt.Sprintf("%s %q \"NAME\" {\n  ...\n}", hb.Type, blockType)
+	}
+
+	if len(hb.Labels) < expectedLabelCount {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Missing %s block name", hb.Type),
+			Detail: fmt.Sprintf("The %s block requires a name label. Add a name to the block declaration, for example:\n\n%s",
+				blockDescription, expectedSyntax),
+			Subject: hb.TypeRange.Ptr(),
+		}}
+	}
+
+	extraLabel := hb.Labels[expectedLabelCount]
+	extraLabelRangeIndex := expectedLabelCount
+	if blockType == "" {
+		extraLabelRangeIndex--
+	}
+	subject := hb.TypeRange.Ptr()
+	if extraLabelRangeIndex < len(hb.LabelRanges) {
+		subject = hb.LabelRanges[extraLabelRangeIndex].Ptr()
+	}
+	return hcl.Diagnostics{&hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  fmt.Sprintf("Extraneous label for %s block", hb.Type),
+		Detail: fmt.Sprintf("The %s block accepts no labels after its name. Remove the extra %q label. Expected syntax:\n\n%s",
+			blockDescription, extraLabel, expectedSyntax),
+		Subject: subject,
+	}}
 }
 
 func blocks(c directedAcyclicGraph) []Block {

--- a/config_test.go
+++ b/config_test.go
@@ -202,6 +202,95 @@ func (s *configSuite) TestInvalidBlockType() {
 	assert.Contains(t, err.Error(), expectedError)
 }
 
+func TestRegisteredBlockLabelValidation(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          string
+		expectedSummary string
+		expectedDetail  string
+		expectedSyntax  string
+	}{
+		{
+			name: "variable missing name",
+			config: `variable {
+  default = "hello"
+}`,
+			expectedSummary: "Missing variable block name",
+			expectedDetail:  `The "variable" block requires a name label`,
+			expectedSyntax:  `variable "NAME" {`,
+		},
+		{
+			name: "variable with extra label",
+			config: `variable "environment" "unexpected" {
+  default = "prod"
+}`,
+			expectedSummary: "Extraneous label for variable block",
+			expectedDetail:  `Remove the extra "unexpected" label`,
+			expectedSyntax:  `variable "NAME" {`,
+		},
+		{
+			name:            "typed block missing name",
+			config:          `data "dummy" {}`,
+			expectedSummary: "Missing data block name",
+			expectedDetail:  `The data "dummy" block requires a name label`,
+			expectedSyntax:  `data "dummy" "NAME" {`,
+		},
+		{
+			name:            "typed block with extra label",
+			config:          `data "dummy" "sample" "unexpected" {}`,
+			expectedSummary: "Extraneous label for data block",
+			expectedDetail:  `Remove the extra "unexpected" label`,
+			expectedSyntax:  `data "dummy" "NAME" {`,
+		},
+		{
+			name:            "root block missing name",
+			config:          `dummy_root {}`,
+			expectedSummary: "Missing dummy_root block name",
+			expectedDetail:  `The "dummy_root" block requires a name label`,
+			expectedSyntax:  `dummy_root "NAME" {`,
+		},
+		{
+			name:            "root block with extra label",
+			config:          `dummy_root "sample" "unexpected" {}`,
+			expectedSummary: "Extraneous label for dummy_root block",
+			expectedDetail:  `Remove the extra "unexpected" label`,
+			expectedSyntax:  `dummy_root "NAME" {`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testBase := newTestBase()
+			defer testBase.teardown()
+			testBase.dummyFsWithFiles(map[string]string{"test.hcl": test.config})
+
+			var err error
+			require.NotPanics(t, func() {
+				_, err = BuildDummyConfig("", "", nil, nil)
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.expectedSummary)
+			assert.Contains(t, err.Error(), test.expectedDetail)
+			assert.Contains(t, err.Error(), test.expectedSyntax)
+			assert.Contains(t, err.Error(), "test.hcl:1")
+		})
+	}
+}
+
+func TestNewBaseBlockWithoutNameIsBoundsSafe(t *testing.T) {
+	hclBlock := &HclBlock{Block: &hclsyntax.Block{
+		Type:   "variable",
+		Labels: []string{""},
+	}}
+
+	var block *BaseBlock
+	require.NotPanics(t, func() {
+		block = NewBaseBlock(nil, hclBlock)
+	})
+	require.NotNil(t, block)
+	assert.Empty(t, block.Name())
+}
+
 func (s *configSuite) TestFunctionInEvalContext() {
 	t := s.T()
 	configStr := `


### PR DESCRIPTION
## Problem

Registered blocks are constructed before Golden validates how many labels they contain. `NewBaseBlock` assumes the normalized `HclBlock.Labels` slice always contains both the block subtype slot and the block name, and reads `Labels[1]` unconditionally.

A syntactically parseable block with a missing name can therefore panic during configuration initialization:

```hcl
variable {
  default = "hello"
}

data "dummy" {
}
```

For root registrations with an empty subtype, parsing adds the synthetic subtype slot but still leaves no name at index 1. The same out-of-range access occurs before Golden can explain the invalid declaration. The inverse case is also malformed but was not rejected clearly:

```hcl
data "dummy" "sample" "unexpected" {
}
```

The extra label could reach the block factory even though it is not part of the registered block syntax. Configuration input should produce a source-ranged diagnostic for both cases, never panic the host process or silently ignore labels.

## Fix

Validate normalized label cardinality in `wrapBlock` after resolving the registered block factory and before invoking it:

- require exactly the subtype/name label shape expected by registered blocks
- for a missing name, point at the block type and show the complete declaration to add, such as `data "dummy" "NAME" { ... }`
- for an extra label, point at that label, quote its value, and show the valid syntax after removal
- tailor diagnostics for untyped forms such as `variable "NAME"`, typed forms such as `data "dummy" "NAME"`, and root block registrations

`NewBaseBlock` is also made bounds-safe as a defensive backstop for callers outside the normal wrapping path. The wrapping boundary remains responsible for returning the actionable HCL diagnostic.

## Tests

Table-driven regression coverage exercises missing and extra labels for:

- built-in variable blocks
- typed data blocks
- registered root blocks

Every case asserts that initialization does not panic and that the error contains the source file, a precise summary, the offending label or missing-name explanation, and the expected syntax. A direct unit test also verifies that `NewBaseBlock` remains bounds-safe with a short label slice.

Validated with:

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `golangci-lint run --timeout=3600s --new-from-rev HEAD`

Fixes #83