### PR TITLE
fix: validate for_each value availability

### DIFF
--- a/base_config.go
+++ b/base_config.go
@@ -297,6 +297,9 @@ func (c *BaseConfig) expandBlock(b Block) ([]Block, error) {
 		return nil, fmt.Errorf("invalid `for_each`, except set or map: %s", attr.Range().String())
 	}
 	address := b.Address()
+	if diags := validateForEachValueAvailability(forEachValue, attr.Expr.Range()); diags.HasErrors() {
+		return nil, diags
+	}
 	upstreams, err := c.d.GetAncestors(address)
 	if err != nil {
 		return nil, err

--- a/for_each.go
+++ b/for_each.go
@@ -1,0 +1,34 @@
+package golden
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func validateForEachValueAvailability(value cty.Value, sourceRange hcl.Range) hcl.Diagnostics {
+	if value.IsNull() {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid for_each value",
+			Detail:   "The for_each expression is null. Use an empty map ({}) or an empty set (toset([])) when no instances should be created.",
+			Subject:  sourceRange.Ptr(),
+		}}
+	}
+	if !value.IsKnown() {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid for_each value",
+			Detail:   "The for_each expression is unknown, so Golden cannot determine which instance keys to create before expansion. Use a map whose keys are known before planning; unknown results can be placed in the map values.",
+			Subject:  sourceRange.Ptr(),
+		}}
+	}
+	if value.Type().IsSetType() && !value.IsWhollyKnown() {
+		return hcl.Diagnostics{&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid for_each value",
+			Detail:   "The for_each set contains values that are unknown before expansion. Set elements become instance keys, so use a map with statically known keys and place unknown results in the map values.",
+			Subject:  sourceRange.Ptr(),
+		}}
+	}
+	return nil
+}

--- a/for_each_value_test.go
+++ b/for_each_value_test.go
@@ -1,0 +1,70 @@
+package golden
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (s *forEachTestSuite) TestForEachNullValueReturnsDiagnostic() {
+	config := `
+variable "items" {
+  type    = map(string)
+  default = null
+}
+
+data "dummy" "sample" {
+  for_each = var.items
+}
+`
+	s.dummyFsWithFiles(map[string]string{"test.hcl": config})
+
+	var err error
+	s.NotPanics(func() {
+		_, err = BuildDummyConfig("", "", nil, nil)
+	})
+	s.Error(err)
+	s.ErrorContains(err, "Invalid for_each value")
+	s.ErrorContains(err, "The for_each expression is null")
+	s.ErrorContains(err, "Use an empty map ({}) or an empty set (toset([]))")
+	s.ErrorContains(err, "test.hcl")
+}
+
+func TestValidateForEachValueAvailability(t *testing.T) {
+	unknownString := cty.UnknownVal(cty.String)
+	sourceRange := hcl.Range{
+		Filename: "test.hcl",
+		Start:    hcl.Pos{Line: 2, Column: 14, Byte: 30},
+		End:      hcl.Pos{Line: 2, Column: 23, Byte: 39},
+	}
+	tests := []struct {
+		name           string
+		value          cty.Value
+		expectedDetail string
+	}{
+		{name: "null map", value: cty.NullVal(cty.Map(cty.String)), expectedDetail: "is null"},
+		{name: "null set", value: cty.NullVal(cty.Set(cty.String)), expectedDetail: "is null"},
+		{name: "unknown map", value: cty.UnknownVal(cty.Map(cty.String)), expectedDetail: "expression is unknown"},
+		{name: "unknown set", value: cty.UnknownVal(cty.Set(cty.String)), expectedDetail: "expression is unknown"},
+		{name: "set with unknown element", value: cty.SetVal([]cty.Value{unknownString}), expectedDetail: "set contains values that are unknown"},
+		{name: "map with known key and unknown value", value: cty.MapVal(map[string]cty.Value{"alpha": unknownString})},
+		{name: "object with known key and unknown value", value: cty.ObjectVal(map[string]cty.Value{"alpha": unknownString})},
+		{name: "list with known index and unknown value", value: cty.ListVal([]cty.Value{unknownString})},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diags := validateForEachValueAvailability(test.value, sourceRange)
+			if test.expectedDetail == "" {
+				require.False(t, diags.HasErrors())
+				return
+			}
+			require.True(t, diags.HasErrors())
+			require.Len(t, diags, 1)
+			require.Contains(t, diags[0].Detail, test.expectedDetail)
+			require.Equal(t, sourceRange, *diags[0].Subject)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`BaseConfig.expandBlock` currently checks only `cty.Value.CanIterateElements()` before calling `ElementIterator()`. `CanIterateElements()` describes whether the value type is iterable; it does not guarantee that the concrete value is available for iteration. A typed null or unknown map/set therefore passes that check, but `ElementIterator()` panics. Invalid or unresolved HCL input can consequently crash the host process instead of returning a configuration diagnostic.

For example, this configuration produces a typed null map:

```hcl
variable "items" {
  type    = map(string)
  default = null
}

data "dummy" "sample" {
  for_each = var.items
}
```

The same failure can occur when an embedding application supplies an unresolved value before expansion:

```go
cty.UnknownVal(cty.Map(cty.String))
```

Both values have iterable collection types, but neither can provide the instance keys required by `for_each`. A set can also be known as a collection while containing an unknown element; because each set element becomes an instance key, such a set cannot be expanded safely.

## Fix

Add a focused availability check before Golden creates the element iterator. The check:

- rejects null collections and tells the author to use an empty map (`{}`) or empty set (`toset([])`) when no instances are required
- rejects wholly unknown collections because Golden cannot determine their instance keys
- rejects sets containing unknown elements because set elements are the instance keys
- allows maps and objects whose keys are known even when their values are unknown, since those unknown values do not change the instance addresses

Each failure is returned as an HCL diagnostic whose subject is the `for_each` expression range. The message explains both why expansion cannot continue and how the configuration should be reshaped. The availability validation is kept separate from the collection-type validation in #85: type validity is checked first, then value/key availability, and only then is `ElementIterator()` called.

## Tests

The regression tests cover typed null maps/sets, wholly unknown maps/sets, sets containing unknown elements, and maps/objects with known keys and unknown values. An end-to-end HCL test also verifies that a null variable default returns an actionable, source-ranged error without panicking.

Validated with:

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `golangci-lint run --timeout=3600s --new-from-rev HEAD^`

Fixes #84