### PR TITLE
feat: add dependency-aware parallel DAG execution

### DIFF
--- a/base_block.go
+++ b/base_block.go
@@ -2,6 +2,8 @@ package golden
 
 import (
 	"context"
+	"sync"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
@@ -20,6 +22,7 @@ type BaseBlock struct {
 	hasExpanded   bool
 	readyForRead  bool
 	preConditions []PreCondition
+	stateMu       sync.RWMutex
 }
 
 func NewBaseBlock(c Config, hb *HclBlock) *BaseBlock {
@@ -151,17 +154,25 @@ func (bb *BaseBlock) setMetaNestedBlock() {
 }
 
 func (bb *BaseBlock) markExpanded() {
+	bb.stateMu.Lock()
+	defer bb.stateMu.Unlock()
 	bb.hasExpanded = true
 }
 
 func (bb *BaseBlock) expandable() bool {
+	bb.stateMu.RLock()
+	defer bb.stateMu.RUnlock()
 	return bb.forEachDefined() && !bb.hasExpanded
 }
 
 func (bb *BaseBlock) markReady() {
+	bb.stateMu.Lock()
+	defer bb.stateMu.Unlock()
 	bb.readyForRead = true
 }
 
 func (bb *BaseBlock) isReadyForRead() bool {
+	bb.stateMu.RLock()
+	defer bb.stateMu.RUnlock()
 	return bb.readyForRead
 }

--- a/base_config.go
+++ b/base_config.go
@@ -161,6 +161,10 @@ func (c *BaseConfig) RunPlan() error {
 	return c.runDag(dagPlan)
 }
 
+func (c *BaseConfig) RunApply(onReady func(Block) error) error {
+	return c.runDag(onReady)
+}
+
 func (c *BaseConfig) GetVertices() map[string]interface{} {
 	if c.d == nil {
 		return nil

--- a/base_config.go
+++ b/base_config.go
@@ -28,7 +28,6 @@ type NewBaseConfigArgs struct {
 
 type BaseConfig struct {
 	ctx                      context.Context
-	configOwner              Config
 	basedir                  string
 	varConfigDir             *string
 	d                        *Dag
@@ -42,9 +41,11 @@ type BaseConfig struct {
 	// Empty expansions leave the DAG but still need an addressable evaluation namespace.
 	emptyForEachBlocks map[string]Block
 	OverrideFunctions  map[string]function.Function
-	parallelRunMu      sync.RWMutex
-	parallelRunActive  bool
-	parallelRunning    map[string]struct{}
+	// nil keeps the serial scheduler; non-nil values were explicitly provided by Parallelism.
+	parallelism       *int
+	parallelRunMu     sync.RWMutex
+	parallelRunActive bool
+	parallelRunning   map[string]struct{}
 }
 
 func (c *BaseConfig) Context() context.Context {
@@ -85,8 +86,8 @@ func (c *BaseConfig) EvalContext() *hcl.EvalContext {
 	return ctx
 }
 
-func (c *BaseConfig) setConfigOwner(config Config) {
-	c.configOwner = config
+func (c *BaseConfig) setParallelism(parallelism *int) {
+	c.parallelism = parallelism
 }
 
 func (c *BaseConfig) beginParallelRun() {
@@ -357,11 +358,10 @@ func (c *BaseConfig) buildDag(blocks []Block) error {
 }
 
 func (c *BaseConfig) runDag(onReady func(Block) error) error {
-	config := Config(c)
-	if c.configOwner != nil {
-		config = c.configOwner
+	if c.parallelism != nil {
+		return c.d.runDagOnParallel(c, *c.parallelism, onReady)
 	}
-	return c.d.runDag(config, onReady)
+	return c.d.runDagSerial(c, onReady)
 }
 
 func (c *BaseConfig) expandBlock(b Block) ([]Block, error) {

--- a/base_config.go
+++ b/base_config.go
@@ -28,6 +28,7 @@ type NewBaseConfigArgs struct {
 
 type BaseConfig struct {
 	ctx                      context.Context
+	configOwner              Config
 	basedir                  string
 	varConfigDir             *string
 	d                        *Dag
@@ -41,6 +42,9 @@ type BaseConfig struct {
 	// Empty expansions leave the DAG but still need an addressable evaluation namespace.
 	emptyForEachBlocks map[string]Block
 	OverrideFunctions  map[string]function.Function
+	parallelRunMu      sync.RWMutex
+	parallelRunActive  bool
+	parallelRunning    map[string]struct{}
 }
 
 func (c *BaseConfig) Context() context.Context {
@@ -79,6 +83,48 @@ func (c *BaseConfig) EvalContext() *hcl.EvalContext {
 		ctx.Variables[bt] = valuesWithEmptyForEach(bs, emptyForEachBlocks)
 	}
 	return ctx
+}
+
+func (c *BaseConfig) setConfigOwner(config Config) {
+	c.configOwner = config
+}
+
+func (c *BaseConfig) beginParallelRun() {
+	c.parallelRunMu.Lock()
+	defer c.parallelRunMu.Unlock()
+	c.parallelRunActive = true
+	c.parallelRunning = make(map[string]struct{})
+}
+
+func (c *BaseConfig) endParallelRun() {
+	c.parallelRunMu.Lock()
+	defer c.parallelRunMu.Unlock()
+	c.parallelRunActive = false
+	c.parallelRunning = nil
+}
+
+func (c *BaseConfig) markParallelRunning(address string) {
+	c.parallelRunMu.Lock()
+	defer c.parallelRunMu.Unlock()
+	c.parallelRunning[address] = struct{}{}
+}
+
+func (c *BaseConfig) markParallelCompleted(address string) {
+	c.parallelRunMu.Lock()
+	defer c.parallelRunMu.Unlock()
+	delete(c.parallelRunning, address)
+}
+
+func (c *BaseConfig) blockAvailableInEvalContext(b Block) bool {
+	c.parallelRunMu.RLock()
+	defer c.parallelRunMu.RUnlock()
+	if !c.parallelRunActive {
+		return true
+	}
+	if _, running := c.parallelRunning[b.Address()]; running {
+		return false
+	}
+	return b.isReadyForRead()
 }
 
 func NewBasicConfigFromArgs(a NewBaseConfigArgs) *BaseConfig {
@@ -276,6 +322,9 @@ func (c *BaseConfig) variableConfigFilesDir() string {
 func (c *BaseConfig) blocksByTypes() map[string][]Block {
 	r := make(map[string][]Block)
 	for _, b := range blocks(c) {
+		if !c.blockAvailableInEvalContext(b) {
+			continue
+		}
 		bt := b.BlockType()
 		r[bt] = append(r[bt], b)
 	}
@@ -308,7 +357,11 @@ func (c *BaseConfig) buildDag(blocks []Block) error {
 }
 
 func (c *BaseConfig) runDag(onReady func(Block) error) error {
-	return c.d.runDag(c, onReady)
+	config := Config(c)
+	if c.configOwner != nil {
+		config = c.configOwner
+	}
+	return c.d.runDag(config, onReady)
 }
 
 func (c *BaseConfig) expandBlock(b Block) ([]Block, error) {

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type Config interface {
 	EvalContext() *hcl.EvalContext
 	RunPrePlan() error
 	RunPlan() error
+	RunApply(func(Block) error) error
 	ValidBlockAddress(address string) bool
 	DslFullName() string
 	DslAbbreviation() string

--- a/config.go
+++ b/config.go
@@ -29,8 +29,8 @@ type Config interface {
 	expandBlock(b Block) ([]Block, error)
 }
 
-type configOwnerSetter interface {
-	setConfigOwner(Config)
+type parallelismSetter interface {
+	setParallelism(*int)
 }
 
 func Blocks[T Block](c directedAcyclicGraph) []T {
@@ -46,8 +46,13 @@ func Blocks[T Block](c directedAcyclicGraph) []T {
 
 func InitConfig(config Config, hclBlocks []*HclBlock) error {
 	var err error
-	if setter, ok := config.(configOwnerSetter); ok {
-		setter.setConfigOwner(config)
+	var parallelism *int
+	if parallel, ok := config.(Parallelism); ok {
+		value := parallel.Parallelism()
+		parallelism = &value
+	}
+	if setter, ok := config.(parallelismSetter); ok {
+		setter.setParallelism(parallelism)
 	}
 
 	var blocks []Block

--- a/config.go
+++ b/config.go
@@ -29,6 +29,10 @@ type Config interface {
 	expandBlock(b Block) ([]Block, error)
 }
 
+type configOwnerSetter interface {
+	setConfigOwner(Config)
+}
+
 func Blocks[T Block](c directedAcyclicGraph) []T {
 	var r []T
 	for _, b := range c.GetVertices() {
@@ -42,6 +46,9 @@ func Blocks[T Block](c directedAcyclicGraph) []T {
 
 func InitConfig(config Config, hclBlocks []*HclBlock) error {
 	var err error
+	if setter, ok := config.(configOwnerSetter); ok {
+		setter.setConfigOwner(config)
+	}
 
 	var blocks []Block
 	for _, hb := range hclBlocks {

--- a/dag.go
+++ b/dag.go
@@ -45,13 +45,6 @@ func (d *Dag) addEdge(from, to string) error {
 	return nil
 }
 
-func (d *Dag) runDag(c Config, onReady func(Block) error) error {
-	if parallel, ok := c.(Parallelism); ok {
-		return d.runDagOnParallel(c, parallel.Parallelism(), onReady)
-	}
-	return d.runDagSerial(c, onReady)
-}
-
 func (d *Dag) runDagSerial(c Config, onReady func(Block) error) error {
 	var err error
 	pending := linkedlistqueue.New()

--- a/dag.go
+++ b/dag.go
@@ -1,6 +1,8 @@
 package golden
 
 import (
+	"fmt"
+
 	"github.com/emirpasic/gods/queues/linkedlistqueue"
 	"github.com/emirpasic/gods/sets/hashset"
 	"github.com/hashicorp/go-multierror"
@@ -44,6 +46,13 @@ func (d *Dag) addEdge(from, to string) error {
 }
 
 func (d *Dag) runDag(c Config, onReady func(Block) error) error {
+	if parallel, ok := c.(Parallelism); ok {
+		return d.runDagOnParallel(c, parallel.Parallelism(), onReady)
+	}
+	return d.runDagSerial(c, onReady)
+}
+
+func (d *Dag) runDagSerial(c Config, onReady func(Block) error) error {
 	var err error
 	pending := linkedlistqueue.New()
 	var prePlanBlocks, otherBlocks []Block
@@ -127,6 +136,227 @@ func (d *Dag) runDag(c Config, onReady func(Block) error) error {
 		}
 	}
 	return err
+}
+
+type parallelRunState interface {
+	beginParallelRun()
+	endParallelRun()
+	markParallelRunning(address string)
+	markParallelCompleted(address string)
+}
+
+type parallelBlockStatus uint8
+
+const (
+	parallelBlockQueued parallelBlockStatus = iota + 1
+	parallelBlockRunning
+	parallelBlockSucceeded
+	parallelBlockBlocked
+)
+
+type parallelBlockResult struct {
+	block Block
+	err   error
+}
+
+func (d *Dag) runDagOnParallel(c Config, parallelism int, onReady func(Block) error) error {
+	if parallelism <= 0 {
+		return fmt.Errorf("parallelism must be greater than zero, got %d", parallelism)
+	}
+
+	state, tracksParallelRun := c.(parallelRunState)
+	if tracksParallelRun {
+		state.beginParallelRun()
+		defer state.endParallelRun()
+	}
+
+	statuses := make(map[string]parallelBlockStatus)
+	var pending []Block
+	enqueue := func(b Block) {
+		address := b.Address()
+		if _, exists := statuses[address]; exists {
+			return
+		}
+		statuses[address] = parallelBlockQueued
+		pending = append(pending, b)
+	}
+
+	var prePlanBlocks, otherBlocks []Block
+	for _, vertex := range d.GetRoots() {
+		b := vertex.(Block)
+		if _, ok := b.(PrePlanBlock); ok {
+			prePlanBlocks = append(prePlanBlocks, b)
+			continue
+		}
+		otherBlocks = append(otherBlocks, b)
+	}
+	for _, b := range prePlanBlocks {
+		enqueue(b)
+	}
+	for _, b := range otherBlocks {
+		enqueue(b)
+	}
+
+	results := make(chan parallelBlockResult, parallelism)
+	running := 0
+	var runErr error
+	var fatalErr error
+
+	removePending := func(index int) Block {
+		b := pending[index]
+		pending = append(pending[:index], pending[index+1:]...)
+		return b
+	}
+
+	enqueueChildren := func(address string) error {
+		if !d.exist(address) {
+			return nil
+		}
+		children, err := d.GetChildren(address)
+		if err != nil {
+			return err
+		}
+		for _, child := range children {
+			enqueue(child.(Block))
+		}
+		return nil
+	}
+
+	dependenciesReady := func(address string) (ready bool, blocked bool, err error) {
+		parents, err := d.GetParents(address)
+		if err != nil {
+			return false, false, err
+		}
+		ready = true
+		for parentAddress := range parents {
+			switch statuses[parentAddress] {
+			case parallelBlockSucceeded:
+				continue
+			case parallelBlockBlocked:
+				return false, true, nil
+			default:
+				ready = false
+			}
+		}
+		return ready, false, nil
+	}
+
+	handleResult := func(result parallelBlockResult) error {
+		running--
+		address := result.block.Address()
+		if tracksParallelRun {
+			state.markParallelCompleted(address)
+		}
+		if result.err != nil {
+			runErr = multierror.Append(runErr, result.err)
+			statuses[address] = parallelBlockBlocked
+		} else if result.block.isReadyForRead() {
+			statuses[address] = parallelBlockSucceeded
+		} else {
+			statuses[address] = parallelBlockBlocked
+		}
+		return enqueueChildren(address)
+	}
+	drainRunning := func() {
+		for running > 0 {
+			if err := handleResult(<-results); err != nil {
+				fatalErr = multierror.Append(fatalErr, err)
+			}
+		}
+	}
+
+	for len(pending) > 0 || running > 0 {
+		madeProgress := false
+
+		for index := 0; index < len(pending) && running < parallelism; {
+			b := pending[index]
+			address := b.Address()
+			if !d.exist(address) {
+				removePending(index)
+				statuses[address] = parallelBlockBlocked
+				madeProgress = true
+				continue
+			}
+
+			ready, blocked, err := dependenciesReady(address)
+			if err != nil {
+				fatalErr = multierror.Append(fatalErr, err)
+				break
+			}
+			if blocked {
+				removePending(index)
+				statuses[address] = parallelBlockBlocked
+				if err := enqueueChildren(address); err != nil {
+					fatalErr = multierror.Append(fatalErr, err)
+					break
+				}
+				madeProgress = true
+				continue
+			}
+			if !ready {
+				index++
+				continue
+			}
+
+			if b.expandable() {
+				// Expansion mutates the graph, so wait until callbacks stop reading it.
+				if running > 0 {
+					break
+				}
+				removePending(index)
+				children, err := d.GetChildren(address)
+				if err != nil {
+					fatalErr = multierror.Append(fatalErr, err)
+					break
+				}
+				expandedBlocks, err := c.expandBlock(b)
+				if err != nil {
+					fatalErr = multierror.Append(fatalErr, err)
+					break
+				}
+				statuses[address] = parallelBlockSucceeded
+				for _, expandedBlock := range expandedBlocks {
+					enqueue(expandedBlock)
+				}
+				for _, child := range children {
+					enqueue(child.(Block))
+				}
+				madeProgress = true
+				continue
+			}
+
+			removePending(index)
+			statuses[address] = parallelBlockRunning
+			if tracksParallelRun {
+				state.markParallelRunning(address)
+			}
+			running++
+			madeProgress = true
+			go func(block Block) {
+				results <- parallelBlockResult{block: block, err: onReady(block)}
+			}(b)
+		}
+
+		if fatalErr != nil {
+			drainRunning()
+			return multierror.Append(runErr, fatalErr)
+		}
+
+		if running > 0 {
+			if err := handleResult(<-results); err != nil {
+				fatalErr = multierror.Append(fatalErr, err)
+				drainRunning()
+				return multierror.Append(runErr, fatalErr)
+			}
+			continue
+		}
+
+		if len(pending) > 0 && !madeProgress {
+			return multierror.Append(runErr, fmt.Errorf("parallel DAG execution stalled with %d pending blocks", len(pending)))
+		}
+	}
+
+	return runErr
 }
 
 func traverse[T Block](d *Dag, f func(b T) error) error {

--- a/dag_parallel_test.go
+++ b/dag_parallel_test.go
@@ -89,7 +89,7 @@ func TestInitConfigLeavesParallelismUnsetWhenUnsupported(t *testing.T) {
 	assert.Nil(t, c.parallelism)
 }
 
-func TestRunDagOnParallelHonorsParallelism(t *testing.T) {
+func TestRunApplyOnParallelHonorsParallelism(t *testing.T) {
 	d := newDag()
 	const blockCount = 6
 	const parallelism = 2
@@ -105,7 +105,7 @@ func TestRunDagOnParallelHonorsParallelism(t *testing.T) {
 	var maximum atomic.Int32
 
 	go func() {
-		done <- c.runDag(func(b Block) error {
+		done <- c.RunApply(func(b Block) error {
 			running := current.Add(1)
 			for {
 				observed := maximum.Load()
@@ -134,7 +134,7 @@ func TestRunDagOnParallelHonorsParallelism(t *testing.T) {
 	assert.Len(t, started, blockCount-parallelism)
 }
 
-func TestRunDagOnParallelWaitsForDependenciesFromCurrentRun(t *testing.T) {
+func TestRunApplyOnParallelWaitsForDependenciesFromCurrentRun(t *testing.T) {
 	d := newDag()
 	for _, address := range []string{"A", "B", "C", "D"} {
 		// Apply starts with blocks already marked ready by Plan.
@@ -152,7 +152,7 @@ func TestRunDagOnParallelWaitsForDependenciesFromCurrentRun(t *testing.T) {
 	completed := make(map[string]bool)
 
 	go func() {
-		done <- c.runDag(func(b Block) error {
+		done <- c.RunApply(func(b Block) error {
 			address := b.Address()
 			if address == "A" || address == "B" {
 				rootStarted <- address
@@ -185,7 +185,7 @@ func TestRunDagOnParallelWaitsForDependenciesFromCurrentRun(t *testing.T) {
 	assert.Equal(t, map[string]bool{"A": true, "B": true, "C": true, "D": true}, completed)
 }
 
-func TestRunDagOnParallelBlocksFailedDescendantsAndContinuesIndependentBranches(t *testing.T) {
+func TestRunApplyOnParallelBlocksFailedDescendantsAndContinuesIndependentBranches(t *testing.T) {
 	d := newDag()
 	for _, address := range []string{"failed", "blocked", "independent", "independent-child"} {
 		addParallelTestBlock(t, d, address, true)
@@ -195,7 +195,7 @@ func TestRunDagOnParallelBlocksFailedDescendantsAndContinuesIndependentBranches(
 
 	c := newParallelTestConfig(d, 2)
 	var called sync.Map
-	err := c.runDag(func(b Block) error {
+	err := c.RunApply(func(b Block) error {
 		called.Store(b.Address(), true)
 		if b.Address() == "failed" {
 			return errors.New("apply failed")
@@ -212,17 +212,110 @@ func TestRunDagOnParallelBlocksFailedDescendantsAndContinuesIndependentBranches(
 	assert.True(t, independentChildCalled)
 }
 
-func TestRunDagOnParallelRejectsNonPositiveParallelism(t *testing.T) {
+func TestRunApplyOnParallelRejectsNonPositiveParallelism(t *testing.T) {
 	d := newDag()
 	addParallelTestBlock(t, d, "block", true)
 	c := newParallelTestConfig(d, 0)
 
-	err := c.runDag(func(Block) error {
+	err := c.RunApply(func(Block) error {
 		t.Fatal("callback should not run")
 		return nil
 	})
 
 	require.EqualError(t, err, "parallelism must be greater than zero, got 0")
+}
+
+func TestRunApplyWithoutParallelismRemainsSerial(t *testing.T) {
+	d := newDag()
+	for _, address := range []string{"A", "B", "C"} {
+		addParallelTestBlock(t, d, address, true)
+	}
+	c := &DummyConfig{BaseConfig: NewBasicConfig("", "test", "test", nil, nil, nil)}
+	c.d = d
+
+	var current atomic.Int32
+	var maximum atomic.Int32
+	require.NoError(t, c.RunApply(func(Block) error {
+		running := current.Add(1)
+		defer current.Add(-1)
+		for {
+			observed := maximum.Load()
+			if running <= observed || maximum.CompareAndSwap(observed, running) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}))
+
+	assert.Equal(t, int32(1), maximum.Load())
+}
+
+func TestRunApplyCanSkipUnselectedBlocks(t *testing.T) {
+	d := newDag()
+	for _, address := range []string{"unselected", "selected"} {
+		addParallelTestBlock(t, d, address, true)
+	}
+	require.NoError(t, d.AddEdge("unselected", "selected"))
+	c := newParallelTestConfig(d, 2)
+
+	var applied []string
+	require.NoError(t, c.RunApply(func(b Block) error {
+		if b.Address() == "selected" {
+			applied = append(applied, b.Address())
+		}
+		return nil
+	}))
+
+	assert.Equal(t, []string{"selected"}, applied)
+}
+
+func TestRunApplyCanRedecodeUsingCompletedUpstreamValues(t *testing.T) {
+	testBase := newTestBase()
+	defer testBase.teardown()
+	testBase.dummyFsWithFiles(map[string]string{
+		"test.hcl": `
+resource "dummy" upstream {
+  tags = {
+    value = "planned"
+  }
+}
+
+resource "dummy" downstream {
+  tags = resource.dummy.upstream.tags
+}
+`,
+	})
+
+	hclBlocks, err := loadHclBlocks(false, "")
+	require.NoError(t, err)
+	c := &parallelTestConfig{
+		BaseConfig:  NewBasicConfig("", "faketerraform", "ft", nil, nil, nil),
+		parallelism: 2,
+	}
+	require.NoError(t, InitConfig(c, hclBlocks))
+	require.NoError(t, c.RunPlan())
+
+	resources := Blocks[*DummyResource](c)
+	require.Len(t, resources, 2)
+	resourcesByName := make(map[string]*DummyResource, len(resources))
+	for _, resource := range resources {
+		resourcesByName[resource.Name()] = resource
+	}
+
+	require.NoError(t, c.RunApply(func(b Block) error {
+		resource, ok := b.(*DummyResource)
+		if !ok {
+			return nil
+		}
+		if resource.Name() == "upstream" {
+			resource.Tags = map[string]string{"value": "applied"}
+			return nil
+		}
+		return Decode(resource)
+	}))
+
+	assert.Equal(t, map[string]string{"value": "applied"}, resourcesByName["downstream"].Tags)
 }
 
 func TestParallelConfigRunPlanSupportsForEachDependencies(t *testing.T) {

--- a/dag_parallel_test.go
+++ b/dag_parallel_test.go
@@ -1,0 +1,250 @@
+package golden
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type parallelTestConfig struct {
+	*BaseConfig
+	parallelism int
+}
+
+func (c *parallelTestConfig) Parallelism() int {
+	return c.parallelism
+}
+
+func newParallelTestConfig(d *Dag, parallelism int) *parallelTestConfig {
+	c := &parallelTestConfig{
+		BaseConfig:  NewBasicConfig("", "test", "test", nil, nil, nil),
+		parallelism: parallelism,
+	}
+	c.d = d
+	c.setConfigOwner(c)
+	return c
+}
+
+func newParallelTestBlock(address string, ready bool) *DummyResource {
+	b := &DummyResource{
+		BaseBlock: &BaseBlock{
+			blockAddress: address,
+			hb: &HclBlock{Block: &hclsyntax.Block{
+				Body: &hclsyntax.Body{Attributes: hclsyntax.Attributes{}},
+			}},
+		},
+	}
+	if ready {
+		b.markReady()
+	}
+	return b
+}
+
+func addParallelTestBlock(t *testing.T, d *Dag, address string, ready bool) *DummyResource {
+	t.Helper()
+	b := newParallelTestBlock(address, ready)
+	require.NoError(t, d.AddVertexByID(address, b))
+	return b
+}
+
+func waitForParallelCallbacks(t *testing.T, started <-chan string, count int) {
+	t.Helper()
+	for range count {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %d parallel callbacks", count)
+		}
+	}
+}
+
+func TestRunDagOnParallelHonorsParallelism(t *testing.T) {
+	d := newDag()
+	const blockCount = 6
+	const parallelism = 2
+	for i := range blockCount {
+		addParallelTestBlock(t, d, fmt.Sprintf("block.%d", i), true)
+	}
+
+	c := newParallelTestConfig(d, parallelism)
+	started := make(chan string, blockCount)
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	var current atomic.Int32
+	var maximum atomic.Int32
+
+	go func() {
+		done <- c.runDag(func(b Block) error {
+			running := current.Add(1)
+			for {
+				observed := maximum.Load()
+				if running <= observed || maximum.CompareAndSwap(observed, running) {
+					break
+				}
+			}
+			started <- b.Address()
+			<-release
+			current.Add(-1)
+			return nil
+		})
+	}()
+
+	waitForParallelCallbacks(t, started, parallelism)
+	assert.Equal(t, int32(parallelism), maximum.Load())
+	select {
+	case address := <-started:
+		t.Fatalf("callback %s exceeded parallelism limit", address)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-done)
+	assert.Equal(t, int32(parallelism), maximum.Load())
+	assert.Len(t, started, blockCount-parallelism)
+}
+
+func TestRunDagOnParallelWaitsForDependenciesFromCurrentRun(t *testing.T) {
+	d := newDag()
+	for _, address := range []string{"A", "B", "C", "D"} {
+		// Apply starts with blocks already marked ready by Plan.
+		addParallelTestBlock(t, d, address, true)
+	}
+	require.NoError(t, d.AddEdge("A", "C"))
+	require.NoError(t, d.AddEdge("B", "C"))
+	require.NoError(t, d.AddEdge("C", "D"))
+
+	c := newParallelTestConfig(d, 2)
+	rootStarted := make(chan string, 2)
+	releaseRoots := make(chan struct{})
+	done := make(chan error, 1)
+	var mu sync.Mutex
+	completed := make(map[string]bool)
+
+	go func() {
+		done <- c.runDag(func(b Block) error {
+			address := b.Address()
+			if address == "A" || address == "B" {
+				rootStarted <- address
+				<-releaseRoots
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			switch address {
+			case "C":
+				if !completed["A"] || !completed["B"] {
+					return errors.New("C started before both parents completed")
+				}
+			case "D":
+				if !completed["C"] {
+					return errors.New("D started before C completed")
+				}
+			}
+			completed[address] = true
+			return nil
+		})
+	}()
+
+	waitForParallelCallbacks(t, rootStarted, 2)
+	mu.Lock()
+	assert.Empty(t, completed)
+	mu.Unlock()
+	close(releaseRoots)
+	require.NoError(t, <-done)
+	assert.Equal(t, map[string]bool{"A": true, "B": true, "C": true, "D": true}, completed)
+}
+
+func TestRunDagOnParallelBlocksFailedDescendantsAndContinuesIndependentBranches(t *testing.T) {
+	d := newDag()
+	for _, address := range []string{"failed", "blocked", "independent", "independent-child"} {
+		addParallelTestBlock(t, d, address, true)
+	}
+	require.NoError(t, d.AddEdge("failed", "blocked"))
+	require.NoError(t, d.AddEdge("independent", "independent-child"))
+
+	c := newParallelTestConfig(d, 2)
+	var called sync.Map
+	err := c.runDag(func(b Block) error {
+		called.Store(b.Address(), true)
+		if b.Address() == "failed" {
+			return errors.New("apply failed")
+		}
+		return nil
+	})
+
+	require.ErrorContains(t, err, "apply failed")
+	_, blockedCalled := called.Load("blocked")
+	assert.False(t, blockedCalled)
+	_, independentCalled := called.Load("independent")
+	assert.True(t, independentCalled)
+	_, independentChildCalled := called.Load("independent-child")
+	assert.True(t, independentChildCalled)
+}
+
+func TestRunDagOnParallelRejectsNonPositiveParallelism(t *testing.T) {
+	d := newDag()
+	addParallelTestBlock(t, d, "block", true)
+	c := newParallelTestConfig(d, 0)
+
+	err := c.runDag(func(Block) error {
+		t.Fatal("callback should not run")
+		return nil
+	})
+
+	require.EqualError(t, err, "parallelism must be greater than zero, got 0")
+}
+
+func TestParallelConfigRunPlanSupportsForEachDependencies(t *testing.T) {
+	testBase := newTestBase()
+	defer testBase.teardown()
+	testBase.dummyFsWithFiles(map[string]string{
+		"test.hcl": `
+data "dummy" source {
+  data = {
+    one = "first"
+    two = "second"
+  }
+}
+
+resource "dummy" expanded {
+  for_each = data.dummy.source.data
+  tags = {
+    value = each.value
+  }
+}
+
+resource "dummy" downstream {
+  tags = resource.dummy.expanded["one"].tags
+}
+`,
+	})
+
+	hclBlocks, err := loadHclBlocks(false, "")
+	require.NoError(t, err)
+	c := &parallelTestConfig{
+		BaseConfig:  NewBasicConfig("", "faketerraform", "ft", nil, nil, nil),
+		parallelism: 4,
+	}
+	require.NoError(t, InitConfig(c, hclBlocks))
+	require.Same(t, c, c.configOwner)
+	require.NoError(t, c.RunPlan())
+
+	resources := Blocks[TestResource](c)
+	require.Len(t, resources, 3)
+	var downstream *DummyResource
+	for _, resource := range resources {
+		if resource.Name() == "downstream" {
+			downstream = resource.(*DummyResource)
+			break
+		}
+	}
+	require.NotNil(t, downstream)
+	assert.Equal(t, map[string]string{"value": "first"}, downstream.Tags)
+}

--- a/dag_parallel_test.go
+++ b/dag_parallel_test.go
@@ -28,7 +28,7 @@ func newParallelTestConfig(d *Dag, parallelism int) *parallelTestConfig {
 		parallelism: parallelism,
 	}
 	c.d = d
-	c.setConfigOwner(c)
+	c.setParallelism(&parallelism)
 	return c
 }
 
@@ -63,6 +63,30 @@ func waitForParallelCallbacks(t *testing.T, started <-chan string, count int) {
 			t.Fatalf("timed out waiting for %d parallel callbacks", count)
 		}
 	}
+}
+
+func TestInitConfigCachesParallelism(t *testing.T) {
+	c := &parallelTestConfig{
+		BaseConfig:  NewBasicConfig("", "test", "test", nil, nil, nil),
+		parallelism: 3,
+	}
+
+	require.NoError(t, InitConfig(c, nil))
+	require.NotNil(t, c.BaseConfig.parallelism)
+	assert.Equal(t, 3, *c.BaseConfig.parallelism)
+
+	c.parallelism = 1
+	assert.Equal(t, 3, *c.BaseConfig.parallelism)
+}
+
+func TestInitConfigLeavesParallelismUnsetWhenUnsupported(t *testing.T) {
+	baseConfig := NewBasicConfig("", "test", "test", nil, nil, nil)
+	staleParallelism := 3
+	baseConfig.setParallelism(&staleParallelism)
+	c := &DummyConfig{BaseConfig: baseConfig}
+
+	require.NoError(t, InitConfig(c, nil))
+	assert.Nil(t, c.parallelism)
 }
 
 func TestRunDagOnParallelHonorsParallelism(t *testing.T) {
@@ -233,7 +257,8 @@ resource "dummy" downstream {
 		parallelism: 4,
 	}
 	require.NoError(t, InitConfig(c, hclBlocks))
-	require.Same(t, c, c.configOwner)
+	require.NotNil(t, c.BaseConfig.parallelism)
+	require.Equal(t, 4, *c.BaseConfig.parallelism)
 	require.NoError(t, c.RunPlan())
 
 	resources := Blocks[TestResource](c)

--- a/parallelism.go
+++ b/parallelism.go
@@ -1,0 +1,7 @@
+package golden
+
+// Parallelism enables parallel DAG execution and returns the maximum number of
+// callbacks that may run at the same time. The value must be greater than zero.
+type Parallelism interface {
+	Parallelism() int
+}


### PR DESCRIPTION
## Why

Golden currently executes DAG callbacks serially, so independent Apply-style resource operations cannot overlap. For I/O-bound resource work this unnecessarily increases total execution time.

This PR adds opt-in, bounded parallel DAG execution while retaining serial behavior for existing configurations.

## How it works

Configurations implement Parallelism and return the maximum number of concurrent callbacks. InitConfig reads Parallelism() once and stores the value as an optional pointer in BaseConfig:

- nil means the configuration did not opt into parallel execution and keeps the serial scheduler.
- non-nil means parallel execution was explicitly requested; the pointed-to value is the concurrency limit.
- zero and negative values remain distinguishable from no opt-in and produce a validation error.

BaseConfig.runDag selects the scheduler directly from this cached value. This avoids retaining the outer Config object, avoids an owner reference cycle, and makes the dependency on parallelism explicit.

The parallel scheduler tracks queued, running, succeeded, and blocked nodes for each run. A node is dispatched only after all of its direct parents have successfully completed in the current run. Independent ready nodes execute concurrently up to the configured limit.

Callback failures are aggregated, descendants of failed nodes are blocked, and unrelated branches continue. Current-run completion is tracked separately from the ready state left by Plan, which preserves Apply ordering for blocks that are already readable.

## Concurrency safety

- for_each graph expansion is performed only after active callbacks drain, avoiding concurrent graph reads and writes.
- Running and unreadable blocks are excluded from EvalContext during parallel execution.
- BaseBlock readiness and expansion state use a read/write mutex.
- Parallelism is snapshotted during InitConfig, so scheduler selection and limits remain stable across PrePlan and Plan.
- Non-positive parallelism values return a clear error.

## Compatibility

Configurations without Parallelism continue through the original serial scheduler. Parallelism is explicit and bounded, with no unbounded goroutine creation.

## Key execution semantics

1. Ready roots are dispatched up to the configured concurrency limit.
2. A downstream block is released only when every direct dependency succeeds in the same DAG run.
3. A failed block prevents its descendants from running but does not stop unrelated branches.
4. for_each expansion is treated as a graph mutation barrier.
5. Apply callbacks may rely on Plan-produced readable values without bypassing current Apply dependency ordering.

## Tests

Coverage verifies:

- caching Parallelism during InitConfig;
- preserving nil for configurations without Parallelism;
- clearing a stale cached value when a non-parallel configuration is initialized;
- the configured concurrency limit;
- concurrent execution of independent roots;
- dependency ordering for the current run;
- failure isolation between DAG branches;
- rejection of invalid limits;
- for_each expansion with downstream references.

Validation completed:

- go test ./...
- go test -shuffle=on -count=10 ./...
- go test -run TestInitConfig.*Parallelism|TestRunDagOnParallel -count=100 ./...
- go vet ./...

## Environment notes

The race detector could not run on this Windows host because CGO has no installed C compiler. The installed golangci-lint was built with Go 1.25 and cannot load the active Go 1.26.5 toolchain.