### PR TITLE
fix: isolate top-level for_each ASTs to prevent nested value corruption

### DIFF
--- a/base_config.go
+++ b/base_config.go
@@ -337,7 +337,8 @@ func (c *BaseConfig) expandBlock(b Block) ([]Block, error) {
 	iterator := forEachValue.ElementIterator()
 	for iterator.Next() {
 		key, value := iterator.Element()
-		newBlock := NewHclBlock(hclBlock.Block, hclBlock.wb, NewForEach(key, value))
+		newBlock := CloneHclBlock(hclBlock)
+		newBlock.ForEach = NewForEach(key, value)
 		nb, err := wrapBlock(b.Config(), newBlock)
 		if err != nil {
 			return nil, err

--- a/for_each_test.go
+++ b/for_each_test.go
@@ -50,6 +50,120 @@ func (s *forEachTestSuite) TestForEachBlockWithAttributeThatHasDefaultValue() {
 	}
 }
 
+func (s *forEachTestSuite) TestStaticNestedBlocksUseInstanceContext() {
+	s.dummyFsWithFiles(map[string]string{
+		"test.hcl": `
+resource "dummy" "expanded" {
+  for_each = {
+    one   = "first"
+    two   = "second"
+    three = "third"
+  }
+
+  nested_block {
+    id   = 1
+    name = each.value
+
+    third_nested_block {
+      name = each.value
+    }
+  }
+}
+`,
+	})
+
+	hclBlocks, err := loadHclBlocks(false, "")
+	require.NoError(s.T(), err)
+	require.Len(s.T(), hclBlocks, 1)
+	sourceNestedAttribute := hclBlocks[0].NestedBlocks()[0].Attributes()["name"].Attribute
+
+	config, err := NewDummyConfig("", nil, hclBlocks, nil)
+	require.NoError(s.T(), err)
+	resources := Blocks[TestResource](config)
+	require.Len(s.T(), resources, 3)
+	for i := 0; i < len(resources); i++ {
+		for j := i + 1; j < len(resources); j++ {
+			left := resources[i].HclBlock()
+			right := resources[j].HclBlock()
+			s.NotSame(left.Block, right.Block)
+			s.NotSame(left.Body, right.Body)
+			s.NotSame(left.Body.Blocks[0], right.Body.Blocks[0])
+			s.NotSame(left.Body.Blocks[0].Body.Blocks[0], right.Body.Blocks[0].Body.Blocks[0])
+		}
+	}
+
+	plan, err := RunDummyPlan(config)
+	require.NoError(s.T(), err)
+	require.Len(s.T(), plan.Resources, 3)
+
+	got := make(map[string][2]string, 3)
+	for _, resource := range plan.Resources {
+		block := resource.(*DummyResource)
+		require.Len(s.T(), block.NestedBlocks, 1)
+		require.Len(s.T(), block.NestedBlocks[0].ThirdNestedBlocks, 1)
+		got[block.Address()] = [2]string{
+			block.NestedBlocks[0].Name,
+			block.NestedBlocks[0].ThirdNestedBlocks[0].Name,
+		}
+	}
+
+	s.Equal(map[string][2]string{
+		"resource.dummy.expanded[one]":   {"first", "first"},
+		"resource.dummy.expanded[two]":   {"second", "second"},
+		"resource.dummy.expanded[three]": {"third", "third"},
+	}, got)
+	s.Same(sourceNestedAttribute, hclBlocks[0].Body.Blocks[0].Body.Attributes["name"])
+}
+
+func (s *forEachTestSuite) TestDynamicNestedBlocksUseInstanceContext() {
+	s.dummyFsWithFiles(map[string]string{
+		"test.hcl": `
+resource "dummy" "expanded" {
+  for_each = {
+    one   = "first"
+    two   = "second"
+    three = "third"
+  }
+
+  dynamic "nested_block" {
+    for_each = [each.value]
+    content {
+      id   = 1
+      name = nested_block.value
+
+      third_nested_block {
+        name = each.value
+      }
+    }
+  }
+}
+`,
+	})
+
+	config, err := BuildDummyConfig("", "", nil, nil)
+	require.NoError(s.T(), err)
+	plan, err := RunDummyPlan(config)
+	require.NoError(s.T(), err)
+	require.Len(s.T(), plan.Resources, 3)
+
+	got := make(map[string][2]string, 3)
+	for _, resource := range plan.Resources {
+		block := resource.(*DummyResource)
+		require.Len(s.T(), block.NestedBlocks, 1)
+		require.Len(s.T(), block.NestedBlocks[0].ThirdNestedBlocks, 1)
+		got[block.Address()] = [2]string{
+			block.NestedBlocks[0].Name,
+			block.NestedBlocks[0].ThirdNestedBlocks[0].Name,
+		}
+	}
+
+	s.Equal(map[string][2]string{
+		"resource.dummy.expanded[one]":   {"first", "first"},
+		"resource.dummy.expanded[two]":   {"second", "second"},
+		"resource.dummy.expanded[three]": {"third", "third"},
+	}, got)
+}
+
 func (s *forEachTestSuite) TestForEachBlockInvolvingVariable() {
 	cases := []struct {
 		config string

--- a/hcl_block.go
+++ b/hcl_block.go
@@ -65,6 +65,10 @@ func AsHclBlocks(syntaxBlocks hclsyntax.Blocks, writeBlocks []*hclwrite.Block) [
 }
 
 func (hb *HclBlock) ExpandDynamicBlocks(evalContext *hcl.EvalContext) (*HclBlock, error) {
+	return CloneHclBlock(hb).expandDynamicBlocks(evalContext)
+}
+
+func (hb *HclBlock) expandDynamicBlocks(evalContext *hcl.EvalContext) (*HclBlock, error) {
 	newHb := &HclBlock{
 		Block:      hb.Block,
 		wb:         hb.wb,
@@ -75,7 +79,7 @@ func (hb *HclBlock) ExpandDynamicBlocks(evalContext *hcl.EvalContext) (*HclBlock
 	var newNestedBlocks []*hclsyntax.Block
 	for _, block := range hb.blocks {
 		if block.Type != "dynamic" {
-			expandedBlock, err := block.ExpandDynamicBlocks(evalContext)
+			expandedBlock, err := block.expandDynamicBlocks(evalContext)
 			if err != nil {
 				return nil, err
 			}
@@ -118,7 +122,7 @@ func (hb *HclBlock) ExpandDynamicBlocks(evalContext *hcl.EvalContext) (*HclBlock
 					return nil, fmt.Errorf("`dynamic` block should contain `content` block only")
 				}
 
-				expandedInnerBlock, err := innerBlock.ExpandDynamicBlocks(newContext)
+				expandedInnerBlock, err := innerBlock.expandDynamicBlocks(newContext)
 				if err != nil {
 					return nil, err
 				}
@@ -210,54 +214,56 @@ func clone[T any](v *T) *T {
 	return &c
 }
 func CloneHclBlock(hb *HclBlock) *HclBlock {
-	// Clone the hclsyntax.Block
 	cloneBlock := CloneHclSyntaxBlock(hb.Block)
+	return cloneHclBlock(hb, cloneBlock)
+}
 
-	// Clone the HclBlock
+func cloneHclBlock(hb *HclBlock, cloneBlock *hclsyntax.Block) *HclBlock {
+	// hclwrite blocks are shared because Golden uses them only to read expression tokens.
 	cloneHb := &HclBlock{
 		Block:      cloneBlock,
-		wb:         clone(hb.wb),
-		ForEach:    hb.ForEach,
-		attributes: make(map[string]*HclAttribute),
+		wb:         hb.wb,
+		attributes: make(map[string]*HclAttribute, len(cloneBlock.Body.Attributes)),
 		blocks:     make([]*HclBlock, len(hb.blocks)),
 	}
-
-	// Clone attributes
-	for name, attr := range hb.attributes {
-		cloneHb.attributes[name] = clone(attr)
+	if hb.ForEach != nil {
+		cloneHb.ForEach = clone(hb.ForEach)
 	}
 
-	// Clone blocks recursively
+	for name, attr := range cloneBlock.Body.Attributes {
+		var writeAttribute *hclwrite.Attribute
+		if sourceAttribute, ok := hb.attributes[name]; ok {
+			writeAttribute = sourceAttribute.wa
+		}
+		cloneHb.attributes[name] = NewHclAttribute(attr, writeAttribute)
+	}
+
 	for i, block := range hb.blocks {
-		cloneHb.blocks[i] = CloneHclBlock(block)
+		cloneHb.blocks[i] = cloneHclBlock(block, cloneBlock.Body.Blocks[i])
 	}
 
 	return cloneHb
 }
 
 func CloneHclSyntaxBlock(hb *hclsyntax.Block) *hclsyntax.Block {
-	// Clone the block itself
 	cloneBlock := clone(hb)
+	cloneBlock.Labels = append([]string(nil), hb.Labels...)
+	cloneBlock.LabelRanges = append([]hcl.Range(nil), hb.LabelRanges...)
 
-	// Clone the body
-	cloneBody := &hclsyntax.Body{
-		Attributes: make(hclsyntax.Attributes),
-		Blocks:     make(hclsyntax.Blocks, len(hb.Body.Blocks)),
-	}
+	cloneBody := clone(hb.Body)
+	cloneBody.Attributes = make(hclsyntax.Attributes, len(hb.Body.Attributes))
+	cloneBody.Blocks = make(hclsyntax.Blocks, len(hb.Body.Blocks))
 
-	// Clone attributes
 	for name, attr := range hb.Body.Attributes {
+		// Expressions are immutable after parsing, so clones can safely share them.
 		cloneBody.Attributes[name] = clone(attr)
 	}
 
-	// Clone blocks recursively
 	for i, block := range hb.Body.Blocks {
 		cloneBody.Blocks[i] = CloneHclSyntaxBlock(block)
 	}
 
-	// Assign the cloned body to the cloned block
 	cloneBlock.Body = cloneBody
-
 	return cloneBlock
 }
 
@@ -267,12 +273,21 @@ func (hb *HclBlock) evaluateAttributes(ctx *hcl.EvalContext) error {
 		if diag.HasErrors() {
 			return diag
 		}
-		hb.Body.Attributes[attributeName] = &hclsyntax.Attribute{
+		evaluatedAttribute := &hclsyntax.Attribute{
 			Name: attributeName,
 			Expr: &hclsyntax.LiteralValueExpr{
 				Val: v,
 			},
-			SrcRange: attribute.SrcRange,
+			SrcRange:    attribute.SrcRange,
+			NameRange:   attribute.NameRange,
+			EqualsRange: attribute.EqualsRange,
+		}
+		hb.Body.Attributes[attributeName] = evaluatedAttribute
+		if wrappedAttribute, ok := hb.attributes[attributeName]; ok {
+			hb.attributes[attributeName] = &HclAttribute{
+				Attribute: evaluatedAttribute,
+				wa:        wrappedAttribute.wa,
+			}
 		}
 	}
 	return nil

--- a/hcl_block_test.go
+++ b/hcl_block_test.go
@@ -57,6 +57,99 @@ func TestNewHclBlock(t *testing.T) {
 	assert.NotNil(t, nb.Attributes()["attr3"])
 }
 
+func TestCloneHclBlockOwnsCoherentSyntaxTree(t *testing.T) {
+	code := `
+block "test" {
+  attr1 = "value1"
+  nested {
+    attr2 = "value2"
+    deep {
+      attr3 = "value3"
+    }
+  }
+}
+`
+	syntaxFile, diag := hclsyntax.ParseConfig([]byte(code), "test.hcl", hcl.InitialPos)
+	require.False(t, diag.HasErrors(), diag.Error())
+	writeFile, diag := hclwrite.ParseConfig([]byte(code), "test.hcl", hcl.InitialPos)
+	require.False(t, diag.HasErrors(), diag.Error())
+
+	original := NewHclBlock(
+		syntaxFile.Body.(*hclsyntax.Body).Blocks[0],
+		writeFile.Body().Blocks()[0],
+		NewForEach(cty.StringVal("key"), cty.StringVal("value")),
+	)
+	cloned := CloneHclBlock(original)
+
+	var assertOwnedClone func(*HclBlock, *HclBlock)
+	assertOwnedClone = func(source, clone *HclBlock) {
+		require.NotSame(t, source.Block, clone.Block)
+		require.NotSame(t, source.Body, clone.Body)
+		require.Equal(t, source.Body.SrcRange, clone.Body.SrcRange)
+		require.Equal(t, source.Body.EndRange, clone.Body.EndRange)
+		require.Equal(t, len(source.Attributes()), len(clone.Attributes()))
+		for name, sourceAttribute := range source.Attributes() {
+			cloneAttribute := clone.Attributes()[name]
+			require.NotSame(t, sourceAttribute.Attribute, cloneAttribute.Attribute)
+			require.Same(t, clone.Body.Attributes[name], cloneAttribute.Attribute)
+		}
+		require.Equal(t, len(source.NestedBlocks()), len(clone.NestedBlocks()))
+		for i := range source.NestedBlocks() {
+			require.Same(t, clone.Body.Blocks[i], clone.NestedBlocks()[i].Block)
+			assertOwnedClone(source.NestedBlocks()[i], clone.NestedBlocks()[i])
+		}
+	}
+	assertOwnedClone(original, cloned)
+	require.NotSame(t, original.ForEach, cloned.ForEach)
+
+	originalAttribute := original.Body.Attributes["attr1"]
+	require.NoError(t, cloned.evaluateAttributes(nil))
+	require.Same(t, originalAttribute, original.Body.Attributes["attr1"])
+	require.Same(t, cloned.Body.Attributes["attr1"], cloned.Attributes()["attr1"].Attribute)
+}
+
+func TestExpandDynamicBlocksDoesNotMutateInput(t *testing.T) {
+	code := `
+resource "dummy" "test" {
+  nested_block {
+    id   = 1
+    name = each.value
+  }
+}
+`
+	syntaxFile, diag := hclsyntax.ParseConfig([]byte(code), "test.hcl", hcl.InitialPos)
+	require.False(t, diag.HasErrors(), diag.Error())
+	writeFile, diag := hclwrite.ParseConfig([]byte(code), "test.hcl", hcl.InitialPos)
+	require.False(t, diag.HasErrors(), diag.Error())
+
+	original := NewHclBlock(
+		syntaxFile.Body.(*hclsyntax.Body).Blocks[0],
+		writeFile.Body().Blocks()[0],
+		nil,
+	)
+	originalNestedBlock := original.Body.Blocks[0]
+	originalNameAttribute := originalNestedBlock.Body.Attributes["name"]
+	evalContext := &hcl.EvalContext{Variables: map[string]cty.Value{
+		"each": cty.ObjectVal(map[string]cty.Value{
+			"key":   cty.StringVal("one"),
+			"value": cty.StringVal("first"),
+		}),
+	}}
+
+	expanded, err := original.ExpandDynamicBlocks(evalContext)
+	require.NoError(t, err)
+	require.Same(t, originalNestedBlock, original.Body.Blocks[0])
+	require.Same(t, originalNameAttribute, original.Body.Blocks[0].Body.Attributes["name"])
+	require.NotSame(t, original.Block, expanded.Block)
+	require.NotSame(t, originalNestedBlock, expanded.Body.Blocks[0])
+	require.Same(t, expanded.Body.Blocks[0], expanded.NestedBlocks()[0].Block)
+	require.Same(t, expanded.Body.Blocks[0].Body.Attributes["name"], expanded.NestedBlocks()[0].Attributes()["name"].Attribute)
+
+	value, diag := expanded.Body.Blocks[0].Body.Attributes["name"].Expr.Value(nil)
+	require.False(t, diag.HasErrors(), diag.Error())
+	require.True(t, value.RawEquals(cty.StringVal("first")))
+}
+
 func TestDynamicBlock_iteratorKey(t *testing.T) {
 	code := `resource "dummy" this {
 	dynamic "nested_block" {


### PR DESCRIPTION
## Why

Fixes #92.

Top-level `for_each` currently creates a distinct Golden wrapper for each instance while reusing the same mutable `*hclsyntax.Block` tree. Planning a nested block evaluates expressions such as `each.value` and replaces them with literal expressions in that shared tree. As a result, one instance can silently decode another instance's nested value even with the serial planner. A parallel planner would also expose concurrent writes and nondeterministic results.

This is a correctness fix for per-instance configuration isolation, not only a concurrency improvement.

## What changed

- Clone the complete `HclBlock` syntax tree for every top-level `for_each` instance before attaching its `ForEach` value.
- Rework `CloneHclBlock` so wrapper attributes and nested blocks point into the same cloned syntax tree instead of a separately cloned tree.
- Preserve body source ranges, block labels, and label ranges while recursively cloning mutable AST containers.
- Make `ExpandDynamicBlocks` clone its input before evaluating or replacing nested expressions, giving the public method a non-mutating input contract.
- Keep the wrapper attribute map synchronized when evaluated syntax attributes are replaced.
- Share `hclwrite.Block` only as read-only source-token data; Golden does not mutate it on these paths.

## Key ownership invariants

After cloning:

- `clone.Attributes()[name].Attribute == clone.Body.Attributes[name]`
- `clone.NestedBlocks()[i].Block == clone.Body.Blocks[i]`
- separate `for_each` instances do not share `Block`, `Body`, attribute, or nested-block pointers

HCL expression objects remain shared because parsed expressions are treated as immutable; only the surrounding attribute and body containers are independently owned.

## Regression coverage

- Reproduces the issue with three top-level instances and verifies `first`, `second`, and `third` remain attached to the correct resource addresses.
- Covers multiple levels of static nested blocks that reference the outer `each.value`.
- Covers top-level `for_each` combined with a `dynamic` nested block.
- Verifies expanded instances own distinct syntax trees.
- Verifies cloning keeps wrapper/syntax pointers coherent.
- Verifies dynamic expansion does not mutate its input AST.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- focused regression set repeated with `-count=25`

`go test -race` was attempted locally, but this Windows environment does not have `gcc`, so the race-enabled build could not be produced. The serial regression is deterministic and the full non-race suite passes.