### PR TITLE
Honor Valuable values without reflection

### DIFF
--- a/block.go
+++ b/block.go
@@ -215,7 +215,12 @@ func valuesWithEmptyForEach[T Block](blocks []T, emptyForEachBlocks []Block) cty
 func blockToCtyValue(b Block) cty.Value {
 	blockValues := map[string]cty.Value{}
 	baseCtyValues := b.BaseValues()
-	ctyValues := Value(b)
+	var ctyValues map[string]cty.Value
+	if valuable, ok := b.(Valuable); ok {
+		ctyValues = valuable.Values()
+	} else {
+		ctyValues = Value(b)
+	}
 	for k, v := range ctyValues {
 		blockValues[k] = v
 	}

--- a/block_test.go
+++ b/block_test.go
@@ -89,6 +89,49 @@ func (d *DummyData) ExecuteDuringPlan() error {
 	return nil
 }
 
+var _ Valuable = (*ValuableDummyData)(nil)
+
+type ValuableDummyData struct {
+	*BaseData
+	*BaseBlock
+	ReflectedValue  string      `hcl:"reflected_value"`
+	ReflectedValues []cty.Value `hcl:"reflected_values"`
+}
+
+func (d *ValuableDummyData) Type() string {
+	return "valuable"
+}
+
+func (d *ValuableDummyData) ExecuteDuringPlan() error {
+	return nil
+}
+
+func (d *ValuableDummyData) Values() map[string]cty.Value {
+	return map[string]cty.Value{
+		"custom_value": cty.StringVal("from Values"),
+		"id":           cty.StringVal("custom-id"),
+	}
+}
+
+func TestBlockToCtyValueUsesValuableValuesWithoutReflection(t *testing.T) {
+	block := &ValuableDummyData{
+		BaseData:       &BaseData{},
+		BaseBlock:      &BaseBlock{id: "block-id"},
+		ReflectedValue: "from reflection",
+		ReflectedValues: []cty.Value{
+			cty.ObjectVal(map[string]cty.Value{"first": cty.True}),
+			cty.ObjectVal(map[string]cty.Value{"second": cty.True}),
+		},
+	}
+
+	value := blockToCtyValue(block)
+
+	assert.Equal(t, "from Values", value.GetAttr("custom_value").AsString())
+	assert.False(t, value.Type().HasAttribute("reflected_value"))
+	assert.False(t, value.Type().HasAttribute("reflected_values"))
+	assert.Equal(t, "block-id", value.GetAttr("id").AsString())
+}
+
 var _ TestResource = &DummyResource{}
 
 type DummyResource struct {


### PR DESCRIPTION
## Summary
- use Valuable.Values() as the complete public cty representation for Valuable blocks
- bypass reflection entirely for Valuable blocks to avoid reflection-time panics
- retain BaseValues() merge order and metadata precedence
- cover heterogeneous reflected values, custom output, omitted reflected fields, and base id precedence

## Tests
- go test ./... -count=1
- go build github.com/Azure/golden
- go vet ./...
- golangci-lint v2.11.4
- Azure/grept at 8eac13e with github.com/Azure/golden replaced by this worktree:
  - full Windows test suite
  - full Linux test suite in golang:1.26.5, including all shell tests skipped on Windows
  - go build github.com/Azure/grept
  - go vet ./...

Fixes #96
