### PR TITLE
Apply optional object attribute defaults to variables

### DIFF
--- a/variable.go
+++ b/variable.go
@@ -97,7 +97,7 @@ func (v *VariableBlock) ExecuteBeforePlan() error {
 	if value == nil {
 		return fmt.Errorf("cannot evaluate value for var.%s", v.Name())
 	}
-	if v.variableType != nil && value.Type() != *v.variableType {
+	if v.variableType != nil && !value.Type().Equals(*v.variableType) {
 		convertedValue, err := convert.Convert(*value, *v.variableType)
 		if err != nil {
 			return fmt.Errorf("incompatible type for var.%s, want %s, got %s", v.Name(), v.variableType.GoString(), value.Type().GoString())

--- a/variable.go
+++ b/variable.go
@@ -31,10 +31,11 @@ type VariableValidation struct {
 
 type VariableBlock struct {
 	*BaseBlock
-	Description   *string
-	Validations   []VariableValidation
-	variableType  *cty.Type
-	variableValue *cty.Value
+	Description      *string
+	Validations      []VariableValidation
+	variableType     *cty.Type
+	variableDefaults *typeexpr.Defaults
+	variableValue    *cty.Value
 }
 
 func (v *VariableBlock) Decode(block *HclBlock, context *hcl.EvalContext) error {
@@ -97,6 +98,10 @@ func (v *VariableBlock) ExecuteBeforePlan() error {
 	if value == nil {
 		return fmt.Errorf("cannot evaluate value for var.%s", v.Name())
 	}
+	if v.variableDefaults != nil {
+		valueWithDefaults := v.variableDefaults.Apply(*value)
+		value = &valueWithDefaults
+	}
 	if v.variableType != nil && !value.Type().Equals(*v.variableType) {
 		convertedValue, err := convert.Convert(*value, *v.variableType)
 		if err != nil {
@@ -112,13 +117,15 @@ func (v *VariableBlock) parseVariableType() error {
 	typeAttr, ok := v.HclBlock().Body.Attributes["type"]
 	if !ok {
 		v.variableType = nil
+		v.variableDefaults = nil
 		return nil
 	}
-	t, diag := typeexpr.Type(typeAttr.Expr)
+	t, defaults, diag := typeexpr.TypeConstraintWithDefaults(typeAttr.Expr)
 	if diag.HasErrors() {
 		return diag
 	}
 	v.variableType = &t
+	v.variableDefaults = defaults
 	return nil
 }
 

--- a/variable_test.go
+++ b/variable_test.go
@@ -298,6 +298,79 @@ func (s *variableSuite) TestExecuteBeforePlan_TypeConvert() {
 	}
 }
 
+func (s *variableSuite) TestExecuteBeforePlan_ObjectType() {
+	cases := []struct {
+		desc          string
+		variableDef   string
+		expectedValue cty.Value
+		expectedError string
+	}{
+		{
+			desc: "accepts an object with the declared type",
+			variableDef: `variable "provider" {
+  type = object({
+    type     = string
+    endpoint = string
+  })
+  default = {
+    type     = "openai"
+    endpoint = "https://example.test/v1"
+  }
+}`,
+			expectedValue: cty.ObjectVal(map[string]cty.Value{
+				"type":     cty.StringVal("openai"),
+				"endpoint": cty.StringVal("https://example.test/v1"),
+			}),
+		},
+		{
+			desc: "converts compatible object attributes",
+			variableDef: `variable "provider" {
+  type = object({
+    name    = string
+    enabled = string
+  })
+  default = {
+    name    = "api"
+    enabled = true
+  }
+}`,
+			expectedValue: cty.ObjectVal(map[string]cty.Value{
+				"name":    cty.StringVal("api"),
+				"enabled": cty.StringVal("true"),
+			}),
+		},
+		{
+			desc: "rejects incompatible object attributes",
+			variableDef: `variable "provider" {
+  type = object({
+    endpoint = string
+  })
+  default = {
+    endpoint = []
+  }
+}`,
+			expectedError: "incompatible type for var.provider",
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.desc, func() {
+			s.dummyFsWithFiles(map[string]string{
+				"test.hcl": c.variableDef,
+			})
+			config, err := BuildDummyConfig("/", "", nil, nil)
+			if c.expectedError != "" {
+				require.Error(s.T(), err)
+				s.Contains(err.Error(), c.expectedError)
+				return
+			}
+			require.NoError(s.T(), err)
+			variable := Blocks[*VariableBlock](config)[0]
+			s.Equal(c.expectedValue, *variable.variableValue)
+		})
+	}
+}
+
 func (s *variableSuite) TestExecuteBeforePlan_Validation() {
 	cases := []struct {
 		desc                      string

--- a/variable_test.go
+++ b/variable_test.go
@@ -371,6 +371,128 @@ func (s *variableSuite) TestExecuteBeforePlan_ObjectType() {
 	}
 }
 
+func (s *variableSuite) TestExecuteBeforePlan_ObjectOptionalAttributeDefaults() {
+	const providerVariable = `variable "provider" {
+  type = object({
+    type     = optional(string, "openai")
+    endpoint = string
+    retry = optional(object({
+      attempts = optional(number, 3)
+    }), {})
+  })
+  default = {
+    endpoint = "https://default.test/v1"
+  }
+}`
+	providerValue := func(providerType, endpoint string, attempts int64) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{
+			"type":     cty.StringVal(providerType),
+			"endpoint": cty.StringVal(endpoint),
+			"retry": cty.ObjectVal(map[string]cty.Value{
+				"attempts": cty.NumberIntVal(attempts),
+			}),
+		})
+	}
+	cases := []struct {
+		desc          string
+		variableDef   string
+		cliFlags      []CliFlagAssignedVariables
+		files         map[string]string
+		envValue      string
+		expectedValue cty.Value
+		expectedError string
+	}{
+		{
+			desc:          "applies nested defaults to the variable default",
+			variableDef:   providerVariable,
+			expectedValue: providerValue("openai", "https://default.test/v1", 3),
+		},
+		{
+			desc:        "applies defaults to a partial CLI value",
+			variableDef: providerVariable,
+			cliFlags: []CliFlagAssignedVariables{
+				NewCliFlagAssignedVariable("provider", `{
+  type     = "azure"
+  endpoint = "https://cli.test/v1"
+}`),
+			},
+			expectedValue: providerValue("azure", "https://cli.test/v1", 3),
+		},
+		{
+			desc:        "applies nested defaults to a variable file value",
+			variableDef: providerVariable,
+			cliFlags: []CliFlagAssignedVariables{
+				NewCliFlagAssignedVariableFile("/test.tfvars"),
+			},
+			files: map[string]string{
+				"/test.tfvars": `provider = {
+  endpoint = "https://file.test/v1"
+  retry    = {}
+}`,
+			},
+			expectedValue: providerValue("openai", "https://file.test/v1", 3),
+		},
+		{
+			desc:        "preserves explicit environment values",
+			variableDef: providerVariable,
+			envValue: `{
+  type     = "custom"
+  endpoint = "https://env.test/v1"
+  retry = {
+    attempts = 5
+  }
+}`,
+			expectedValue: providerValue("custom", "https://env.test/v1", 5),
+		},
+		{
+			desc:        "rejects a partial value missing a required attribute",
+			variableDef: providerVariable,
+			cliFlags: []CliFlagAssignedVariables{
+				NewCliFlagAssignedVariable("provider", `{}`),
+			},
+			expectedError: "incompatible type for var.provider",
+		},
+		{
+			desc: "supports optional attributes without explicit defaults",
+			variableDef: `variable "provider" {
+  type = object({
+    endpoint    = string
+    description = optional(string)
+  })
+  default = {
+    endpoint = "https://example.test/v1"
+  }
+}`,
+			expectedValue: cty.ObjectVal(map[string]cty.Value{
+				"endpoint":    cty.StringVal("https://example.test/v1"),
+				"description": cty.NullVal(cty.String),
+			}),
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.desc, func() {
+			if c.envValue != "" {
+				s.T().Setenv("FT_VAR_provider", c.envValue)
+			}
+			s.dummyFsWithFiles(c.files)
+			s.dummyFsWithFiles(map[string]string{
+				"test.hcl": c.variableDef,
+			})
+			config, err := BuildDummyConfig("/", "", c.cliFlags, nil)
+			if c.expectedError != "" {
+				require.Error(s.T(), err)
+				s.Contains(err.Error(), c.expectedError)
+				return
+			}
+			require.NoError(s.T(), err)
+			variable := Blocks[*VariableBlock](config)[0]
+			s.True(c.expectedValue.RawEquals(*variable.variableValue),
+				"expected %#v, got %#v", c.expectedValue, *variable.variableValue)
+		})
+	}
+}
+
 func (s *variableSuite) TestExecuteBeforePlan_Validation() {
 	cases := []struct {
 		desc                      string


### PR DESCRIPTION
## Summary
- parse variable declarations as type constraints with optional attribute defaults
- retain and apply nested HCL defaults after selecting the winning input source
- preserve existing type conversion, required-attribute errors, and validation behavior
- cover variable defaults, CLI values, var files, environment values, required attributes, and optional attributes without explicit defaults

## Dependency
Depends on #95. The current main branch panics when comparing the object value produced after defaults are applied, so this branch is stacked on the structural type-comparison fix. The issue #98 implementation is the second commit in this PR.

## Tests
- go test ./... -count=1
- go build github.com/Azure/golden
- go vet ./...
- golangci-lint v2.11.4
- Azure/grept at 8eac13e with github.com/Azure/golden replaced by this worktree:
  - full Windows test suite
  - full Linux test suite in golang:1.26.5, including shell tests skipped on Windows
  - go build github.com/Azure/grept
  - go vet ./...

Fixes #98
