### PR TITLE
fix: pair local expressions by name

### DIFF
--- a/hcl_block.go
+++ b/hcl_block.go
@@ -2,6 +2,8 @@ package golden
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -55,11 +57,59 @@ func NewForEach(key, value cty.Value) *ForEach {
 func AsHclBlocks(syntaxBlocks hclsyntax.Blocks, writeBlocks []*hclwrite.Block) []*HclBlock {
 	var blocks []*HclBlock
 	for i, b := range syntaxBlocks {
-		var rbs = readRawHclSyntaxBlock(b)
-		var wbs = readRawHclWriteBlock(writeBlocks[i])
-		for i, hb := range rbs {
-			blocks = append(blocks, NewHclBlock(hb, wbs[i], nil))
+		if b.Type == "locals" {
+			blocks = append(blocks, readRawHclLocalBlocks(b, writeBlocks[i])...)
+			continue
 		}
+		var rbs = readRawHclSyntaxBlock(b)
+		for _, hb := range rbs {
+			blocks = append(blocks, NewHclBlock(hb, writeBlocks[i], nil))
+		}
+	}
+	return blocks
+}
+
+func readRawHclLocalBlocks(syntaxBlock *hclsyntax.Block, writeBlock *hclwrite.Block) []*HclBlock {
+	syntaxAttributes := syntaxBlock.Body.Attributes
+	writeAttributes := writeBlock.Body().Attributes()
+	if len(syntaxAttributes) != len(writeAttributes) {
+		panic("syntax and write locals blocks contain different numbers of attributes")
+	}
+
+	names := make([]string, 0, len(syntaxAttributes))
+	for name := range syntaxAttributes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	blocks := make([]*HclBlock, 0, len(names))
+	for _, name := range names {
+		syntaxAttribute := syntaxAttributes[name]
+		writeAttribute, ok := writeAttributes[name]
+		if !ok {
+			panic(fmt.Sprintf("write attribute %q is missing from the corresponding locals block", name))
+		}
+
+		rb := &hclsyntax.Block{
+			Type:   "local",
+			Labels: []string{"", name},
+			Body: &hclsyntax.Body{
+				Attributes: map[string]*hclsyntax.Attribute{
+					"value": {
+						Name:        "value",
+						Expr:        syntaxAttribute.Expr,
+						SrcRange:    syntaxAttribute.SrcRange,
+						NameRange:   syntaxAttribute.NameRange,
+						EqualsRange: syntaxAttribute.EqualsRange,
+					},
+				},
+				SrcRange: syntaxAttribute.NameRange,
+				EndRange: syntaxAttribute.SrcRange,
+			},
+		}
+		wb := hclwrite.NewBlock("local", []string{"", name})
+		wb.Body().SetAttributeRaw("value", writeAttribute.Expr().BuildTokens(hclwrite.Tokens{}))
+		blocks = append(blocks, NewHclBlock(rb, wb, nil))
 	}
 	return blocks
 }
@@ -137,30 +187,6 @@ func (hb *HclBlock) ExpandDynamicBlocks(evalContext *hcl.EvalContext) (*HclBlock
 
 func readRawHclSyntaxBlock(b *hclsyntax.Block) []*hclsyntax.Block {
 	switch b.Type {
-	case "locals":
-		{
-			var newBlocks []*hclsyntax.Block
-			for _, attr := range b.Body.Attributes {
-				newBlocks = append(newBlocks, &hclsyntax.Block{
-					Type:   "local",
-					Labels: []string{"", attr.Name},
-					Body: &hclsyntax.Body{
-						Attributes: map[string]*hclsyntax.Attribute{
-							"value": {
-								Name:        "value",
-								Expr:        attr.Expr,
-								SrcRange:    attr.SrcRange,
-								NameRange:   attr.NameRange,
-								EqualsRange: attr.EqualsRange,
-							},
-						},
-						SrcRange: attr.NameRange,
-						EndRange: attr.SrcRange,
-					},
-				})
-			}
-			return newBlocks
-		}
 	case "variable":
 		{
 			return []*hclsyntax.Block{
@@ -190,19 +216,6 @@ func readRawHclSyntaxBlock(b *hclsyntax.Block) []*hclsyntax.Block {
 
 		return []*hclsyntax.Block{b}
 	}
-}
-
-func readRawHclWriteBlock(b *hclwrite.Block) []*hclwrite.Block {
-	if b.Type() != "locals" {
-		return []*hclwrite.Block{b}
-	}
-	var newBlocks []*hclwrite.Block
-	for n, attr := range b.Body().Attributes() {
-		nb := hclwrite.NewBlock("local", []string{"", n})
-		nb.Body().SetAttributeRaw("value", attr.Expr().BuildTokens(hclwrite.Tokens{}))
-		newBlocks = append(newBlocks, nb)
-	}
-	return newBlocks
 }
 
 func clone[T any](v *T) *T {

--- a/hcl_block_test.go
+++ b/hcl_block_test.go
@@ -1,16 +1,19 @@
 package golden
 
 import (
-	"github.com/prashantv/gostub"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/require"
-	"github.com/zclconf/go-cty/cty"
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/prashantv/gostub"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestNewHclBlock(t *testing.T) {
@@ -55,6 +58,44 @@ func TestNewHclBlock(t *testing.T) {
 	assert.Equal(t, "nested", nb.Type)
 	assert.Equal(t, 1, len(nb.Attributes()))
 	assert.NotNil(t, nb.Attributes()["attr3"])
+}
+
+func TestAsHclBlocksPreservesLocalExpressionNames(t *testing.T) {
+	var source strings.Builder
+	source.WriteString("locals {\n")
+	expectedNames := make([]string, 64)
+	for index := range expectedNames {
+		name := fmt.Sprintf("local_%02d", index)
+		expectedNames[index] = name
+		fmt.Fprintf(&source, "  %s = %q\n", name, fmt.Sprintf("expression_%02d", index))
+	}
+	source.WriteString("}\n")
+
+	syntaxFile, diagnostics := hclsyntax.ParseConfig([]byte(source.String()), "locals.hcl", hcl.InitialPos)
+	require.False(t, diagnostics.HasErrors(), diagnostics.Error())
+	writeFile, diagnostics := hclwrite.ParseConfig([]byte(source.String()), "locals.hcl", hcl.InitialPos)
+	require.False(t, diagnostics.HasErrors(), diagnostics.Error())
+
+	for range 1024 {
+		blocks := AsHclBlocks(
+			syntaxFile.Body.(*hclsyntax.Body).Blocks,
+			writeFile.Body().Blocks(),
+		)
+		require.Len(t, blocks, len(expectedNames))
+		actualNames := make([]string, len(blocks))
+		for index, block := range blocks {
+			name := block.Labels[1]
+			actualNames[index] = name
+			suffix := strings.TrimPrefix(name, "local_")
+			expectedExpression := "expression_" + suffix
+			attribute := block.Attributes()["value"]
+			require.Equal(t, strconv.Quote(expectedExpression), attribute.ExprString(), name)
+			value, err := attribute.Value(nil)
+			require.NoError(t, err, name)
+			require.Equal(t, expectedExpression, value.AsString(), name)
+		}
+		require.Equal(t, expectedNames, actualNames)
+	}
 }
 
 func TestDynamicBlock_iteratorKey(t *testing.T) {


### PR DESCRIPTION
## Why

`AsHclBlocks` converted a `locals` block by iterating the syntax and write attribute maps independently, then pairing the generated blocks by slice index. Go map iteration order is not stable, so a local could retain a sibling local's write expression while still evaluating its own syntax expression.

Fixes #100.

## What

- convert syntax and write local attributes together using the attribute name;
- sort local names to make the generated block order deterministic;
- preserve the existing `AsHclBlocks` API and non-local conversion behavior;
- add regression coverage that repeatedly checks local names, evaluated values, preserved expressions, and output order.

## Tests

- go test ./...
- go test -run '^TestAsHclBlocksPreservesLocalExpressionNames$' -count=10 ./...
- go test -shuffle=on -count=10 ./...
- go vet ./...